### PR TITLE
chore: set Artifact Hub repositoryID for ownership claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,20 +77,39 @@ All metrics tagged with `consumer_group`, `topic`, `partition` where applicable.
 
 ### Helm Chart
 
+The chart is published to a Helm repository served from GitHub Pages and indexed on
+[Artifact Hub](https://artifacthub.io/packages/helm/klag/klag).
+
 ```bash
-helm install klag ./charts/klag \
+helm repo add klag https://themoah.github.io/klag
+helm repo update
+helm search repo klag   # find the latest version
+
+helm install klag klag/klag \
   --set kafka.bootstrapServers="kafka-broker:9092"
 ```
+
+Pin a specific version with `--version`, e.g. `helm install klag klag/klag --version 0.1.12 ...`.
 
 <details>
 <summary>With SASL authentication</summary>
 
 ```bash
-helm install klag ./charts/klag \
+helm install klag klag/klag \
   --set kafka.bootstrapServers="kafka:9092" \
   --set kafka.securityProtocol="SASL_SSL" \
   --set kafka.saslMechanism="PLAIN" \
   --set kafka.saslJaasConfig="org.apache.kafka.common.security.plain.PlainLoginModule required username='user' password='pass';"
+```
+
+</details>
+
+<details>
+<summary>Install from a local checkout (development)</summary>
+
+```bash
+helm install klag ./charts/klag \
+  --set kafka.bootstrapServers="kafka-broker:9092"
 ```
 
 </details>

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,10 +1,6 @@
 # ArtifactHub repository ownership verification.
 # See: https://artifacthub.io/docs/topics/ownership-claim/
-#
-# SETUP REQUIRED: After registering on https://artifacthub.io,
-# replace the placeholder below with the repositoryID UUID from
-# your repository settings page.
-repositoryID: REPLACE-WITH-UUID-FROM-ARTIFACTHUB-SETTINGS
+repositoryID: 56cbf9e0-4059-46f4-b85a-bab2cf3fca9b
 owners:
   - name: themoah
     homeURL: https://github.com/themoah


### PR DESCRIPTION
Sets the real `repositoryID` in `artifacthub-repo.yml` (was a placeholder), completing the Artifact Hub ownership claim.

UUID is a public repo identifier, not a secret — Artifact Hub fetches this file from the gh-pages root to verify ownership.

On merge, the `Release Helm Chart` workflow syncs `artifacthub-repo.yml` to gh-pages automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)