### PR TITLE
ci: build Docker image on chart-releaser tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@ name: Release
 
 on:
   push:
+    # chart-releaser tags the chart as klag-<version>; plain semver tags are
+    # also supported. Any tag triggers a build of the matching image.
     tags:
-      - 'v*'
-      # chart-releaser tags the Helm chart as klag-<version>; build the image too
-      # so the appVersion image referenced by the chart always exists.
       - 'klag-*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
     inputs:
       version:
@@ -42,13 +42,12 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${GITHUB_REF_NAME}" == klag-* ]]; then
-            # Chart tag (klag-<chartVersion>): use appVersion from build.gradle.kts.
-            VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' build.gradle.kts)
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          elif [[ -n "${{ inputs.version }}" ]]; then
+          if [[ -n "${{ inputs.version }}" ]]; then
             VERSION="${{ inputs.version }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # Strip any tag prefix (klag-, v, ...) leaving the bare semver.
+            VERSION="${GITHUB_REF_NAME##*-}"
+            VERSION="${VERSION#v}"
           else
             VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' build.gradle.kts)
           fi
@@ -93,6 +92,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: Klag v${{ steps.version.outputs.version }}
-          tag_name: v${{ steps.version.outputs.version }}
+          tag_name: ${{ steps.version.outputs.version }}
           generate_release_notes: true
           files: build/libs/klag-${{ steps.version.outputs.version }}-fat.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+      # chart-releaser tags the Helm chart as klag-<version>; build the image too
+      # so the appVersion image referenced by the chart always exists.
+      - 'klag-*'
   workflow_dispatch:
     inputs:
       version:
@@ -39,7 +42,10 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${GITHUB_REF_NAME}" == klag-* ]]; then
+            # Chart tag (klag-<chartVersion>): use appVersion from build.gradle.kts.
+            VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' build.gradle.kts)
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           elif [[ -n "${{ inputs.version }}" ]]; then
             VERSION="${{ inputs.version }}"
@@ -87,6 +93,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: Klag v${{ steps.version.outputs.version }}
-          tag_name: ${{ github.event_name == 'push' && github.ref_name || format('v{0}', steps.version.outputs.version) }}
+          tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
           files: build/libs/klag-${{ steps.version.outputs.version }}-fat.jar


### PR DESCRIPTION
## Problem

ArtifactHub fails scanning the chart's referenced image:

```
error scanning image themoah/klag:0.1.12: image not found (package klag:0.1.12)
```

The `Release` workflow (Docker build/push) only triggered on `v*` tags. But `helm-release.yml`'s chart-releaser tags the chart as `klag-<version>`. Bumping the chart to 0.1.12 created tag `klag-0.1.12` (not `v0.1.12`), so `release.yml` never ran and `themoah/klag:0.1.12` was never built. Last image built was `v0.1.10`; `0.1.11` and `0.1.12` are both missing on Docker Hub and GHCR. Chart.yaml's `artifacthub.io/images` annotation points at the non-existent `0.1.12`.

## Fix

- Trigger `Release` on `klag-*` tags too, so a chart release also builds the matching image.
- For `klag-*` tags, derive the image version from `appVersion` in `build.gradle.kts` (source of truth) rather than the chart-version tag.
- Always cut the app release as `v<version>` to avoid colliding with the `klag-<version>` chart tag.

Result: chart bump → image auto-built; no more drift between chart appVersion and published image.

## Follow-up (not in this PR)

The missing `0.1.12` image still needs a one-time build:

```
gh workflow run release.yml -f version=0.1.12
```

After that, ArtifactHub's next rescan passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)