### PR TITLE
feat(config): map all KAFKA_* env vars to kafka client properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,9 @@ src/main/java/io/github/themoah/klag/
 
 ## Environment Variables
 
-**App:** `HTTP_PORT` (8888), `KAFKA_HEALTH_CHECK_INTERVAL_MS` (30000), `VERTX_USE_VIRTUAL_THREADS` (false)
+**App:** `HTTP_PORT` (8888), `KAFKA_HEALTH_CHECK_INTERVAL_MS` (30000), `VERTX_USE_VIRTUAL_THREADS` (false), `KLAG_CONFIG_FILE` (path to external `application.properties`, optional)
 
-**Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1), `KAFKA_CHUNK_DELAY_MS` (0)
+**Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1), `KAFKA_CHUNK_DELAY_MS` (0). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
 
 **Metrics:** `METRICS_REPORTER` (none/prometheus/datadog/otlp), `METRICS_INTERVAL_MS` (60000), `METRICS_GROUP_FILTER` (comma-separated glob patterns, default `*`), `METRICS_GROUP_EXCLUDE` (comma-separated glob patterns, default empty), `METRICS_JVM_ENABLED` (false). A group is monitored iff it matches any include segment AND no exclude segment.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.1.13"
+version = "0.1.14"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.1.12
-appVersion: "0.1.12"
+version: 0.2.0
+appVersion: "0.1.14"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -32,7 +32,7 @@ annotations:
       url: https://github.com/themoah/klag/blob/main/README.md
   artifacthub.io/images: |
     - name: klag
-      image: themoah/klag:0.1.12
+      image: themoah/klag:0.1.14
   artifacthub.io/maintainers: |
     - name: themoah
       email: aviv@dozorets.com

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -120,6 +120,8 @@ helm install klag ./charts/klag \
 
 Any other `KAFKA_*` env var set on the pod is automatically picked up by klag and mapped to the equivalent Kafka client property (e.g. `KAFKA_SSL_TRUSTSTORE_PASSWORD` → `ssl.truststore.password`).
 
+Set `KLAG_CONFIG_FILE` to the path of an external `application.properties` (typically mounted from a ConfigMap or Secret via `extraVolumes` / `extraVolumeMounts`) to layer file-based config between the classpath defaults and `KAFKA_*` env vars. Precedence: classpath `application.properties` < `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
+
 ### Metrics Configuration
 
 | Parameter | Description | Default |

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -42,6 +42,26 @@ helm install klag ./charts/klag \
   --set kafka.existingSecret="kafka-creds"
 ```
 
+### With SASL_SSL and Private Truststore
+
+When the brokers present certs signed by an internal CA, mount the truststore via
+`extraVolumes` / `extraVolumeMounts` and point `kafka.sslTruststoreLocation` at it.
+
+```bash
+helm install klag ./charts/klag \
+  --set kafka.bootstrapServers="kafka:9093" \
+  --set kafka.securityProtocol="SASL_SSL" \
+  --set kafka.saslMechanism="PLAIN" \
+  --set kafka.existingSecret="kafka-creds" \
+  --set kafka.sslTruststoreLocation="/etc/shared-certificates/kafka/client.truststore.jks" \
+  --set-json 'extraVolumes=[{"name":"shared-certificates","persistentVolumeClaim":{"claimName":"shared-certificates-volume-claim"}}]' \
+  --set-json 'extraVolumeMounts=[{"name":"shared-certificates","mountPath":"/etc/shared-certificates","readOnly":true}]'
+```
+
+If the truststore is password-protected, also set `KAFKA_SSL_TRUSTSTORE_PASSWORD`
+(via `--set-json` env injection or by mounting it from a secret) — klag picks it
+up automatically as `ssl.truststore.password`.
+
 ### With OTLP Metrics (Grafana Cloud)
 
 ```bash
@@ -94,8 +114,11 @@ helm install klag ./charts/klag \
 | `kafka.securityProtocol` | Security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL) | `""` |
 | `kafka.saslMechanism` | SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512) | `""` |
 | `kafka.saslJaasConfig` | JAAS configuration string | `""` |
+| `kafka.sslTruststoreLocation` | Path inside the container to the SSL truststore (emits `KAFKA_SSL_TRUSTSTORE_LOCATION`) | `""` |
 | `kafka.existingSecret` | Name of existing secret for Kafka credentials | `""` |
 | `kafka.secretKeys.jaasConfig` | Key in secret for JAAS config | `jaas-config` |
+
+Any other `KAFKA_*` env var set on the pod is automatically picked up by klag and mapped to the equivalent Kafka client property (e.g. `KAFKA_SSL_TRUSTSTORE_PASSWORD` → `ssl.truststore.password`).
 
 ### Metrics Configuration
 
@@ -177,6 +200,8 @@ helm install klag ./charts/klag \
 | `podAnnotations` | Pod annotations | `{}` |
 | `podSecurityContext` | Pod security context | `{}` |
 | `securityContext` | Container security context | `{}` |
+| `extraVolumes` | Additional pod-level volumes (e.g., truststore PVC, certs Secret) | `[]` |
+| `extraVolumeMounts` | Additional container volume mounts; pair with `extraVolumes` | `[]` |
 
 ### ServiceAccount Configuration
 

--- a/charts/klag/templates/deployment.yaml
+++ b/charts/klag/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
                   name: {{ include "klag.kafkaSecretName" . }}
                   key: {{ .Values.kafka.secretKeys.jaasConfig }}
             {{- end }}
+            {{- if .Values.kafka.sslTruststoreLocation }}
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: {{ .Values.kafka.sslTruststoreLocation | quote }}
+            {{- end }}
             # Metrics configuration
             - name: METRICS_REPORTER
               value: {{ .Values.metrics.reporter | quote }}
@@ -144,6 +148,14 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/klag/values.yaml
+++ b/charts/klag/values.yaml
@@ -52,6 +52,11 @@ kafka:
   # JAAS configuration string for SASL authentication
   # Example: org.apache.kafka.common.security.plain.PlainLoginModule required username="user" password="pass";
   saslJaasConfig: ""
+  # Path to the SSL truststore file inside the container. When set, the chart emits
+  # KAFKA_SSL_TRUSTSTORE_LOCATION so the AdminClient can verify broker certs.
+  # Typically combined with extraVolumes/extraVolumeMounts to mount a secret or PVC
+  # carrying the JKS/PKCS12 truststore.
+  sslTruststoreLocation: ""
   # Use an existing secret for Kafka credentials instead of creating one
   existingSecret: ""
   # Keys in the existing secret
@@ -152,6 +157,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional volumes to attach to the pod (e.g., truststore PVC, certs ConfigMap).
+# Example:
+#   - name: shared-certificates
+#     persistentVolumeClaim:
+#       claimName: shared-certificates-volume-claim
+extraVolumes: []
+
+# Additional volume mounts for the klag container. Pair with extraVolumes.
+# Example:
+#   - name: shared-certificates
+#     mountPath: /etc/shared-certificates
+#     readOnly: true
+extraVolumeMounts: []
 
 # Prometheus ServiceMonitor configuration
 serviceMonitor:

--- a/src/main/java/io/github/themoah/klag/MainVerticle.java
+++ b/src/main/java/io/github/themoah/klag/MainVerticle.java
@@ -44,7 +44,7 @@ public class MainVerticle extends AbstractVerticle {
 
     AppConfig appConfig = AppConfig.fromEnvironment();
     MetricsConfig metricsConfig = MetricsConfig.fromEnvironment();
-    KafkaClientConfig kafkaConfig = loadKafkaConfig();
+    KafkaClientConfig kafkaConfig = KafkaClientConfig.load();
 
     kafkaClientService = new KafkaClientServiceImpl(vertx, kafkaConfig);
     healthMonitor = new KafkaHealthMonitor(vertx, kafkaClientService, appConfig.healthCheckIntervalMs());
@@ -119,15 +119,6 @@ public class MainVerticle extends AbstractVerticle {
       .listen(port)
       .onSuccess(server -> log.info("HTTP server started on port {}", port))
       .onFailure(err -> log.error("Failed to start HTTP server", err));
-  }
-
-  private KafkaClientConfig loadKafkaConfig() {
-    try {
-      return KafkaClientConfig.fromClasspath();
-    } catch (Exception e) {
-      log.info("No classpath config found, loading from environment: {}", e.getMessage());
-      return KafkaClientConfig.fromEnvironment();
-    }
   }
 
   private MetricsCollector createMetricsCollector(MetricsConfig config, Router router) {

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -234,7 +235,8 @@ public class KafkaClientConfig {
         continue;
       }
       String propertyKey =
-        PROP_PREFIX + name.substring(ENV_PREFIX.length()).toLowerCase().replace('_', '.');
+        PROP_PREFIX
+          + name.substring(ENV_PREFIX.length()).toLowerCase(Locale.ROOT).replace('_', '.');
       props.setProperty(propertyKey, value);
     }
   }

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
  * <ol>
  *   <li>Built-in defaults</li>
  *   <li>{@code application.properties} on the classpath (if present)</li>
+ *   <li>External properties file referenced by {@code KLAG_CONFIG_FILE} (if set and readable)</li>
  *   <li>Environment variables — any {@code KAFKA_X_Y_Z} maps to {@code kafka.x.y.z}
  *       (lowercase, underscores become dots). For example
  *       {@code KAFKA_SECURITY_PROTOCOL} sets {@code kafka.security.protocol}.</li>
@@ -38,6 +39,7 @@ public class KafkaClientConfig {
   private static final String PROP_REQUEST_TIMEOUT_MS = "kafka.request.timeout.ms";
   private static final String PROP_PREFIX = "kafka.";
   private static final String ENV_PREFIX = "KAFKA_";
+  private static final String EXTERNAL_CONFIG_ENV = "KLAG_CONFIG_FILE";
 
   private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 30000;
@@ -77,8 +79,9 @@ public class KafkaClientConfig {
 
   /**
    * Loads configuration with full layered precedence: defaults &lt; classpath
-   * {@code application.properties} &lt; {@code KAFKA_*} environment variables.
-   * Placeholders in values are resolved against the process environment.
+   * {@code application.properties} &lt; external file referenced by {@code KLAG_CONFIG_FILE}
+   * &lt; {@code KAFKA_*} environment variables. Placeholders in values are resolved against
+   * the process environment.
    */
   public static KafkaClientConfig load() {
     return load(System.getenv());
@@ -87,6 +90,10 @@ public class KafkaClientConfig {
   static KafkaClientConfig load(Map<String, String> env) {
     Properties props = new Properties();
     loadClasspathInto(props, DEFAULT_CONFIG_FILE);
+    String externalPath = env.get(EXTERNAL_CONFIG_ENV);
+    if (externalPath != null && !externalPath.isBlank()) {
+      loadFileInto(props, Path.of(externalPath));
+    }
     applyEnvironmentOverrides(props, env);
     resolvePlaceholders(props, env);
     return fromProperties(props);
@@ -191,6 +198,24 @@ public class KafkaClientConfig {
       props.load(is);
     } catch (IOException e) {
       log.warn("Failed to load {}: {}", resourceName, e.getMessage());
+    }
+  }
+
+  /**
+   * Layers properties from an external file path on top of the existing bag.
+   * If the file is missing or unreadable, the failure is logged and the bag is unchanged —
+   * the caller can still fall back to env vars / defaults.
+   */
+  static void loadFileInto(Properties props, Path path) {
+    if (!Files.isReadable(path)) {
+      log.warn("External config file not readable, skipping: {}", path);
+      return;
+    }
+    try (InputStream is = Files.newInputStream(path)) {
+      log.info("Loading configuration from external file: {}", path);
+      props.load(is);
+    } catch (IOException e) {
+      log.warn("Failed to load external config file {}: {}", path, e.getMessage());
     }
   }
 

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
@@ -48,6 +48,8 @@ public class KafkaClientConfig {
   private static final Pattern PLACEHOLDER_PATTERN =
     Pattern.compile("\\$\\{([^${}:]+)(?::([^}]*))?}");
 
+  private static final int MAX_PLACEHOLDER_PASSES = 10;
+
   private final String bootstrapServers;
   private final int requestTimeoutMs;
   private final Map<String, String> additionalProperties;
@@ -244,16 +246,29 @@ public class KafkaClientConfig {
   /**
    * Resolves {@code ${VAR}} and {@code ${VAR:default}} placeholders in property values.
    * Looks up the variable in the environment first, then in the properties bag itself.
-   * Unresolved placeholders are left as-is.
+   * Resolution runs as a fixed-point iteration (up to {@link #MAX_PLACEHOLDER_PASSES}
+   * passes) so chained references — e.g. {@code A=${B}}, {@code B=${ENV_VAR}} — fully
+   * resolve regardless of iteration order. Unresolved placeholders are left as-is;
+   * cycles terminate at the pass cap.
    */
   static void resolvePlaceholders(Properties props, Map<String, String> env) {
-    for (String name : props.stringPropertyNames()) {
-      String value = props.getProperty(name);
-      String resolved = resolveString(value, env, props);
-      if (!Objects.equals(value, resolved)) {
-        props.setProperty(name, resolved);
+    for (int pass = 0; pass < MAX_PLACEHOLDER_PASSES; pass++) {
+      boolean changed = false;
+      for (String name : props.stringPropertyNames()) {
+        String value = props.getProperty(name);
+        String resolved = resolveString(value, env, props);
+        if (!Objects.equals(value, resolved)) {
+          props.setProperty(name, resolved);
+          changed = true;
+        }
+      }
+      if (!changed) {
+        return;
       }
     }
+    log.warn(
+      "Placeholder resolution did not stabilise after {} passes; possible cycle",
+      MAX_PLACEHOLDER_PASSES);
   }
 
   private static String resolveString(String value, Map<String, String> env, Properties props) {

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientConfig.java
@@ -8,12 +8,26 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Configuration holder for Kafka Admin Client.
+ * Configuration holder for the Kafka Admin Client.
+ *
+ * <p>Configuration is layered Spring Boot-style; later sources override earlier ones:
+ * <ol>
+ *   <li>Built-in defaults</li>
+ *   <li>{@code application.properties} on the classpath (if present)</li>
+ *   <li>Environment variables — any {@code KAFKA_X_Y_Z} maps to {@code kafka.x.y.z}
+ *       (lowercase, underscores become dots). For example
+ *       {@code KAFKA_SECURITY_PROTOCOL} sets {@code kafka.security.protocol}.</li>
+ * </ol>
+ *
+ * <p>Property values may contain {@code ${VAR}} or {@code ${VAR:default}} placeholders;
+ * placeholders are resolved against environment variables (then other properties).
  */
 public class KafkaClientConfig {
 
@@ -23,9 +37,13 @@ public class KafkaClientConfig {
   private static final String PROP_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
   private static final String PROP_REQUEST_TIMEOUT_MS = "kafka.request.timeout.ms";
   private static final String PROP_PREFIX = "kafka.";
+  private static final String ENV_PREFIX = "KAFKA_";
 
   private static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+
+  private static final Pattern PLACEHOLDER_PATTERN =
+    Pattern.compile("\\$\\{([^${}:]+)(?::([^}]*))?}");
 
   private final String bootstrapServers;
   private final int requestTimeoutMs;
@@ -57,70 +75,75 @@ public class KafkaClientConfig {
     return new Builder();
   }
 
-  public static KafkaClientConfig fromEnvironment() {
-    return builder()
-      .bootstrapServers(
-        System.getenv().getOrDefault("KAFKA_BOOTSTRAP_SERVERS", DEFAULT_BOOTSTRAP_SERVERS)
-      )
-      .requestTimeoutMs(
-        Integer.parseInt(
-          System.getenv().getOrDefault("KAFKA_REQUEST_TIMEOUT_MS",
-            String.valueOf(DEFAULT_REQUEST_TIMEOUT_MS))
-        )
-      )
-      .build();
+  /**
+   * Loads configuration with full layered precedence: defaults &lt; classpath
+   * {@code application.properties} &lt; {@code KAFKA_*} environment variables.
+   * Placeholders in values are resolved against the process environment.
+   */
+  public static KafkaClientConfig load() {
+    return load(System.getenv());
+  }
+
+  static KafkaClientConfig load(Map<String, String> env) {
+    Properties props = new Properties();
+    loadClasspathInto(props, DEFAULT_CONFIG_FILE);
+    applyEnvironmentOverrides(props, env);
+    resolvePlaceholders(props, env);
+    return fromProperties(props);
   }
 
   /**
-   * Loads configuration from the default application.properties file on the classpath.
-   *
-   * @return KafkaClientConfig loaded from classpath
-   * @throws IOException if the config file cannot be read
+   * Loads configuration purely from environment variables (no classpath file).
+   * Provided for backward compatibility; prefer {@link #load()}.
+   */
+  public static KafkaClientConfig fromEnvironment() {
+    return fromEnvironment(System.getenv());
+  }
+
+  static KafkaClientConfig fromEnvironment(Map<String, String> env) {
+    Properties props = new Properties();
+    applyEnvironmentOverrides(props, env);
+    resolvePlaceholders(props, env);
+    return fromProperties(props);
+  }
+
+  /**
+   * Loads configuration from the default {@code application.properties} on the classpath
+   * (without env var overrides). Provided for backward compatibility; prefer {@link #load()}.
    */
   public static KafkaClientConfig fromClasspath() throws IOException {
     return fromClasspath(DEFAULT_CONFIG_FILE);
   }
 
-  /**
-   * Loads configuration from a properties file on the classpath.
-   *
-   * @param resourceName the name of the properties file on the classpath
-   * @return KafkaClientConfig loaded from the resource
-   * @throws IOException if the config file cannot be read
-   */
   public static KafkaClientConfig fromClasspath(String resourceName) throws IOException {
     log.info("Loading configuration from classpath: {}", resourceName);
-    try (InputStream is = KafkaClientConfig.class.getClassLoader().getResourceAsStream(resourceName)) {
+    try (InputStream is =
+        KafkaClientConfig.class.getClassLoader().getResourceAsStream(resourceName)) {
       if (is == null) {
         throw new IOException("Resource not found on classpath: " + resourceName);
       }
       Properties props = new Properties();
       props.load(is);
+      resolvePlaceholders(props, System.getenv());
       return fromProperties(props);
     }
   }
 
-  /**
-   * Loads configuration from a properties file at the given path.
-   *
-   * @param path the path to the properties file
-   * @return KafkaClientConfig loaded from the file
-   * @throws IOException if the file cannot be read
-   */
   public static KafkaClientConfig fromFile(Path path) throws IOException {
     log.info("Loading configuration from file: {}", path);
     try (InputStream is = Files.newInputStream(path)) {
       Properties props = new Properties();
       props.load(is);
+      resolvePlaceholders(props, System.getenv());
       return fromProperties(props);
     }
   }
 
   /**
-   * Creates configuration from a Properties object.
-   *
-   * @param props the properties containing kafka.* configuration
-   * @return KafkaClientConfig built from the properties
+   * Builds a {@link KafkaClientConfig} from an already-resolved {@link Properties} bag.
+   * All {@code kafka.*} keys are pulled through; {@code kafka.bootstrap.servers} and
+   * {@code kafka.request.timeout.ms} are surfaced as first-class fields, the rest pass
+   * through to the AdminClient as additional properties.
    */
   public static KafkaClientConfig fromProperties(Properties props) {
     Builder builder = builder();
@@ -132,15 +155,19 @@ public class KafkaClientConfig {
 
     String requestTimeout = props.getProperty(PROP_REQUEST_TIMEOUT_MS);
     if (requestTimeout != null && !requestTimeout.isBlank()) {
-      builder.requestTimeoutMs(Integer.parseInt(requestTimeout));
+      try {
+        builder.requestTimeoutMs(Integer.parseInt(requestTimeout));
+      } catch (NumberFormatException e) {
+        log.warn(
+          "Invalid integer for {}: {}, using default: {}",
+          PROP_REQUEST_TIMEOUT_MS, requestTimeout, DEFAULT_REQUEST_TIMEOUT_MS);
+      }
     }
 
-    // Add any additional kafka.* properties (for security, etc.)
     for (String name : props.stringPropertyNames()) {
       if (name.startsWith(PROP_PREFIX)
           && !name.equals(PROP_BOOTSTRAP_SERVERS)
           && !name.equals(PROP_REQUEST_TIMEOUT_MS)) {
-        // Convert kafka.security.protocol -> security.protocol
         String kafkaKey = name.substring(PROP_PREFIX.length());
         builder.property(kafkaKey, props.getProperty(name));
       }
@@ -150,6 +177,83 @@ public class KafkaClientConfig {
     return builder.build();
   }
 
+  // --- internals ---
+
+  private static void loadClasspathInto(Properties props, String resourceName) {
+    try (InputStream is =
+        KafkaClientConfig.class.getClassLoader().getResourceAsStream(resourceName)) {
+      if (is == null) {
+        log.debug(
+          "No {} on classpath; relying on environment variables and defaults", resourceName);
+        return;
+      }
+      log.info("Loading configuration from classpath: {}", resourceName);
+      props.load(is);
+    } catch (IOException e) {
+      log.warn("Failed to load {}: {}", resourceName, e.getMessage());
+    }
+  }
+
+  /**
+   * Layers {@code KAFKA_*} environment variables into the properties bag (env wins).
+   * Each {@code KAFKA_X_Y_Z} env var becomes {@code kafka.x.y.z}.
+   */
+  static void applyEnvironmentOverrides(Properties props, Map<String, String> env) {
+    for (Map.Entry<String, String> entry : env.entrySet()) {
+      String name = entry.getKey();
+      if (name == null || !name.startsWith(ENV_PREFIX) || name.length() == ENV_PREFIX.length()) {
+        continue;
+      }
+      String value = entry.getValue();
+      if (value == null) {
+        continue;
+      }
+      String propertyKey =
+        PROP_PREFIX + name.substring(ENV_PREFIX.length()).toLowerCase().replace('_', '.');
+      props.setProperty(propertyKey, value);
+    }
+  }
+
+  /**
+   * Resolves {@code ${VAR}} and {@code ${VAR:default}} placeholders in property values.
+   * Looks up the variable in the environment first, then in the properties bag itself.
+   * Unresolved placeholders are left as-is.
+   */
+  static void resolvePlaceholders(Properties props, Map<String, String> env) {
+    for (String name : props.stringPropertyNames()) {
+      String value = props.getProperty(name);
+      String resolved = resolveString(value, env, props);
+      if (!Objects.equals(value, resolved)) {
+        props.setProperty(name, resolved);
+      }
+    }
+  }
+
+  private static String resolveString(String value, Map<String, String> env, Properties props) {
+    if (value == null || value.indexOf("${") < 0) {
+      return value;
+    }
+    Matcher m = PLACEHOLDER_PATTERN.matcher(value);
+    StringBuilder out = new StringBuilder();
+    while (m.find()) {
+      String var = m.group(1);
+      String dflt = m.group(2);
+      String replacement = env.get(var);
+      if (replacement == null) {
+        replacement = props.getProperty(var);
+      }
+      if (replacement == null) {
+        replacement = dflt;
+      }
+      if (replacement == null) {
+        replacement = m.group(0);
+      }
+      m.appendReplacement(out, Matcher.quoteReplacement(replacement));
+    }
+    m.appendTail(out);
+    return out.toString();
+  }
+
   public static class Builder {
 
     private String bootstrapServers = DEFAULT_BOOTSTRAP_SERVERS;
@@ -157,7 +261,8 @@ public class KafkaClientConfig {
     private final Map<String, String> additionalProperties = new HashMap<>();
 
     public Builder bootstrapServers(String bootstrapServers) {
-      this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers cannot be null");
+      this.bootstrapServers =
+        Objects.requireNonNull(bootstrapServers, "bootstrapServers cannot be null");
       return this;
     }
 

--- a/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class KafkaClientConfigTest {
 
@@ -134,5 +137,37 @@ class KafkaClientConfigTest {
 
     assertEquals("localhost:9092", config.getBootstrapServers());
     assertEquals(30000, config.getRequestTimeoutMs());
+  }
+
+  @Test
+  void externalFile_overridesClasspathAndIsOverriddenByEnv(@TempDir Path tmp) throws Exception {
+    Path external = tmp.resolve("application.properties");
+    Files.writeString(
+      external,
+      """
+      kafka.bootstrap.servers=from-file:9092
+      kafka.security.protocol=SASL_PLAINTEXT
+      kafka.client.id=from-file
+      """);
+    Map<String, String> env = Map.of(
+      "KLAG_CONFIG_FILE", external.toString(),
+      "KAFKA_CLIENT_ID", "from-env");
+
+    KafkaClientConfig config = KafkaClientConfig.load(env);
+
+    assertEquals("from-file:9092", config.getBootstrapServers());
+    assertEquals("SASL_PLAINTEXT", config.toProperties().get("security.protocol"));
+    assertEquals("from-env", config.toProperties().get("client.id"));
+  }
+
+  @Test
+  void externalFile_missingPathIsIgnored() {
+    Map<String, String> env = Map.of(
+      "KLAG_CONFIG_FILE", "/does/not/exist.properties",
+      "KAFKA_BOOTSTRAP_SERVERS", "broker:9092");
+
+    KafkaClientConfig config = KafkaClientConfig.load(env);
+
+    assertEquals("broker:9092", config.getBootstrapServers());
   }
 }

--- a/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
@@ -1,0 +1,138 @@
+package io.github.themoah.klag.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.junit.jupiter.api.Test;
+
+class KafkaClientConfigTest {
+
+  @Test
+  void envBinding_mapsKafkaPrefixedVarsToKafkaProperties() {
+    Map<String, String> env = new HashMap<>();
+    env.put("KAFKA_BOOTSTRAP_SERVERS", "broker:9093");
+    env.put("KAFKA_SECURITY_PROTOCOL", "SASL_SSL");
+    env.put("KAFKA_SASL_MECHANISM", "PLAIN");
+    env.put("KAFKA_SSL_TRUSTSTORE_LOCATION", "/etc/certs/client.truststore.jks");
+
+    KafkaClientConfig config = KafkaClientConfig.fromEnvironment(env);
+
+    assertEquals("broker:9093", config.getBootstrapServers());
+    Map<String, String> props = config.toProperties();
+    assertEquals("SASL_SSL", props.get("security.protocol"));
+    assertEquals("PLAIN", props.get("sasl.mechanism"));
+    assertEquals("/etc/certs/client.truststore.jks", props.get("ssl.truststore.location"));
+  }
+
+  @Test
+  void envBinding_requestTimeoutParsedAsInt() {
+    Map<String, String> env = Map.of("KAFKA_REQUEST_TIMEOUT_MS", "45000");
+
+    KafkaClientConfig config = KafkaClientConfig.fromEnvironment(env);
+
+    assertEquals(45000, config.getRequestTimeoutMs());
+    assertEquals(
+      "45000",
+      config.toProperties().get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG));
+  }
+
+  @Test
+  void envBinding_ignoresNonKafkaPrefix() {
+    Map<String, String> env = Map.of(
+      "HTTP_PORT", "9999",
+      "PATH", "/usr/bin",
+      "KAFKAFOO", "bar");
+
+    KafkaClientConfig config = KafkaClientConfig.fromEnvironment(env);
+
+    Map<String, String> props = config.toProperties();
+    assertFalse(props.containsKey("foo"));
+    assertFalse(props.containsKey("kafkafoo"));
+  }
+
+  @Test
+  void envBinding_skipsLoneKafkaPrefixAndNullValues() {
+    Map<String, String> env = new HashMap<>();
+    env.put("KAFKA_", "stray");
+    env.put("KAFKA_SECURITY_PROTOCOL", null);
+    env.put("KAFKA_BOOTSTRAP_SERVERS", "broker:9092");
+
+    KafkaClientConfig config = KafkaClientConfig.fromEnvironment(env);
+
+    Map<String, String> props = config.toProperties();
+    assertEquals("broker:9092", config.getBootstrapServers());
+    assertNull(props.get("security.protocol"));
+  }
+
+  @Test
+  void merge_envOverridesPropertiesFile() {
+    Properties props = new Properties();
+    props.setProperty("kafka.bootstrap.servers", "from-file:9092");
+    props.setProperty("kafka.security.protocol", "PLAINTEXT");
+    Map<String, String> env = Map.of(
+      "KAFKA_BOOTSTRAP_SERVERS", "from-env:9092",
+      "KAFKA_SASL_MECHANISM", "PLAIN");
+
+    KafkaClientConfig.applyEnvironmentOverrides(props, env);
+    KafkaClientConfig.resolvePlaceholders(props, env);
+    KafkaClientConfig config = KafkaClientConfig.fromProperties(props);
+
+    assertEquals("from-env:9092", config.getBootstrapServers());
+    assertEquals("PLAINTEXT", config.toProperties().get("security.protocol"));
+    assertEquals("PLAIN", config.toProperties().get("sasl.mechanism"));
+  }
+
+  @Test
+  void placeholders_resolvedFromEnvironment() {
+    Properties props = new Properties();
+    props.setProperty(
+      "kafka.sasl.jaas.config",
+      "org.apache.kafka.common.security.plain.PlainLoginModule required "
+        + "username=\"${SASL_USERNAME}\" password=\"${SASL_PASSWORD}\";");
+    Map<String, String> env = Map.of(
+      "SASL_USERNAME", "alice",
+      "SASL_PASSWORD", "s3cret");
+
+    KafkaClientConfig.resolvePlaceholders(props, env);
+    KafkaClientConfig config = KafkaClientConfig.fromProperties(props);
+
+    String jaas = config.toProperties().get("sasl.jaas.config");
+    assertTrue(jaas.contains("username=\"alice\""), jaas);
+    assertTrue(jaas.contains("password=\"s3cret\""), jaas);
+  }
+
+  @Test
+  void placeholders_useDefaultWhenEnvMissing() {
+    Properties props = new Properties();
+    props.setProperty("kafka.client.id", "${CLIENT_ID:klag-default}");
+
+    KafkaClientConfig.resolvePlaceholders(props, Map.of());
+    KafkaClientConfig config = KafkaClientConfig.fromProperties(props);
+
+    assertEquals("klag-default", config.toProperties().get("client.id"));
+  }
+
+  @Test
+  void placeholders_leftAsIsWhenUnresolvable() {
+    Properties props = new Properties();
+    props.setProperty("kafka.client.id", "${MISSING_VAR}");
+
+    KafkaClientConfig.resolvePlaceholders(props, Map.of());
+
+    assertEquals("${MISSING_VAR}", props.getProperty("kafka.client.id"));
+  }
+
+  @Test
+  void defaults_appliedWhenNoSourcesProvided() {
+    KafkaClientConfig config = KafkaClientConfig.fromEnvironment(Map.of());
+
+    assertEquals("localhost:9092", config.getBootstrapServers());
+    assertEquals(30000, config.getRequestTimeoutMs());
+  }
+}

--- a/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
@@ -123,6 +123,40 @@ class KafkaClientConfigTest {
   }
 
   @Test
+  void placeholders_resolveChainedPropertyToPropertyToEnv() {
+    Properties props = new Properties();
+    props.setProperty("kafka.sasl.jaas.config", "${JAAS_TEMPLATE}");
+    props.setProperty(
+      "JAAS_TEMPLATE",
+      "org.apache.kafka.common.security.plain.PlainLoginModule required "
+        + "username=\"${SASL_USERNAME}\" password=\"${SASL_PASSWORD}\";");
+    Map<String, String> env = Map.of(
+      "SASL_USERNAME", "alice",
+      "SASL_PASSWORD", "s3cret");
+
+    KafkaClientConfig.resolvePlaceholders(props, env);
+
+    String jaas = props.getProperty("kafka.sasl.jaas.config");
+    assertTrue(jaas.contains("username=\"alice\""), jaas);
+    assertTrue(jaas.contains("password=\"s3cret\""), jaas);
+    assertFalse(jaas.contains("${"), jaas);
+  }
+
+  @Test
+  void placeholders_cycleTerminatesWithoutHanging() {
+    Properties props = new Properties();
+    props.setProperty("kafka.a", "${kafka.b}");
+    props.setProperty("kafka.b", "${kafka.a}");
+
+    // Must return; the assertion is implicit (no infinite loop).
+    KafkaClientConfig.resolvePlaceholders(props, Map.of());
+
+    // Values remain placeholder-shaped because the cycle can never resolve.
+    assertTrue(props.getProperty("kafka.a").contains("${"));
+    assertTrue(props.getProperty("kafka.b").contains("${"));
+  }
+
+  @Test
   void placeholders_leftAsIsWhenUnresolvable() {
     Properties props = new Properties();
     props.setProperty("kafka.client.id", "${MISSING_VAR}");

--- a/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/KafkaClientConfigTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -158,6 +159,22 @@ class KafkaClientConfigTest {
     assertEquals("from-file:9092", config.getBootstrapServers());
     assertEquals("SASL_PLAINTEXT", config.toProperties().get("security.protocol"));
     assertEquals("from-env", config.toProperties().get("client.id"));
+  }
+
+  @Test
+  void envBinding_localeIndependentLowercase() {
+    Locale previous = Locale.getDefault();
+    try {
+      // Turkish locale famously maps 'I' -> 'ı' (dotless i) under default toLowerCase().
+      Locale.setDefault(new Locale("tr", "TR"));
+      Map<String, String> env = Map.of("KAFKA_CLIENT_ID", "klag-prod");
+
+      KafkaClientConfig config = KafkaClientConfig.fromEnvironment(env);
+
+      assertEquals("klag-prod", config.toProperties().get("client.id"));
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `KafkaClientConfig.fromEnvironment()` previously honoured only `KAFKA_BOOTSTRAP_SERVERS` and `KAFKA_REQUEST_TIMEOUT_MS`; every other `KAFKA_*` env var was silently dropped, so `SASL_SSL` / SSL truststore / JAAS config never reached the AdminClient when configured purely via the environment. Config now follows Spring Boot-style precedence (defaults < classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars), with `KAFKA_X_Y_Z` mapped to `kafka.x.y.z` (using `Locale.ROOT` so the mapping is JVM-locale-independent) and `${VAR}` / `${VAR:default}` placeholder substitution in property values. Placeholders resolve via fixed-point iteration so chained references (`A=${B}`, `B=${ENV}`) fully resolve regardless of iteration order; cycles terminate after 10 passes with a warning.
- Helm chart now exposes `kafka.sslTruststoreLocation` (emits `KAFKA_SSL_TRUSTSTORE_LOCATION`) plus generic `extraVolumes` / `extraVolumeMounts` so callers can mount a private-CA truststore PVC at the path referenced by `sslTruststoreLocation`. Any other `KAFKA_*` env (e.g. `KAFKA_SSL_TRUSTSTORE_PASSWORD`) now flows through automatically without needing dedicated chart support.
- Versions bumped: klag `0.1.13` → `0.1.14`, chart `0.1.12` → `0.2.0`, chart `appVersion` `0.1.12` → `0.1.14`.

## Notes

- Full unit-test suite green (existing tests plus 13 new `KafkaClientConfigTest` cases covering relaxed binding, env-over-file precedence, external-file precedence, locale-independent key mapping, single and chained placeholder resolution, cycle termination, defaults, and stray-env safety).
- `scripts/test-helm-chart.sh` clean: 37/37 helm template/lint assertions pass.
- Backward compatible: chart renders are unchanged when the new values are unset; the older `KafkaClientConfig.fromClasspath()` / `fromEnvironment()` entry points are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)