### PR TITLE
Fix/mythos fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Each group snapshot also carries a **basic lag trend** (`growing`/`shrinking`/`s
 `overallTrend`; `diagnose` flags frequent state changes (rebalance storm / flapping).
 See `docs/superpowers/specs/2026-06-01-mcp-support-design.md`.
 
-**Logging:** `LOG_LEVEL`, `LOG_LEVEL_KLAG`, `LOG_LEVEL_KAFKA`, `LOG_LEVEL_HEALTH`, `LOG_LEVEL_METRICS`, `LOG_LEVEL_KAFKA_CLIENT` (Apache kafka-clients, default `INFO`), `LOG_LEVEL_KAFKA_LIST_OFFSETS_HANDLER` (Apache `ListOffsetsHandler`, default `ERROR` — silences the redundant per-scrape MAX_TIMESTAMP WARN on Kafka <3.0; raise to `WARN`/`DEBUG` when investigating other listOffsets issues)
+**Logging:** `LOG_LEVEL`, `LOG_LEVEL_KLAG` (falls back to `LOG_LEVEL`, then `INFO`), `LOG_LEVEL_KAFKA`, `LOG_LEVEL_HEALTH`, `LOG_LEVEL_METRICS`, `LOG_LEVEL_KAFKA_CLIENT` (Apache kafka-clients, default `INFO`), `LOG_LEVEL_KAFKA_LIST_OFFSETS_HANDLER` (Apache `ListOffsetsHandler`, default `ERROR` — silences the redundant per-scrape MAX_TIMESTAMP WARN on Kafka <3.0; raise to `WARN`/`DEBUG` when investigating other listOffsets issues)
 
 
 **OTLP Configuration (when METRICS_REPORTER=otlp):**
@@ -168,6 +168,7 @@ OTEL_RESOURCE_ATTRIBUTES=environment=development,cluster=local
 Note: `klag.hot_partition` only has `topic` and `partition` tags (throughput is partition-level, independent of consumers)
 Note: Time-based lag metrics only have `consumer_group` and `topic` tags (per-topic granularity)
 Note: DLP metrics only have `consumer_group` and `topic` tags (per-topic granularity)
+Note: `klag.consumer.group.state` carries the state as a *tag*; on a state change the old-state series survives 1–2 collection intervals (two-phase stale-gauge cleanup), so both states export during that window. Key alerts on the most recent sample rather than series existence.
 
 ## Grafana Dashboard
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 # Build stage
 FROM eclipse-temurin:21-jdk AS builder
 
+ARG GRADLE_VERSION=8.14.3
+ARG GRADLE_SHA256=bd71102213493060956ec229d946beee57158dbd89d0e62b91bca0fa2c5f3531
+
 WORKDIR /app
 
-# Install Gradle
+# Install Gradle (checksum-verified download, same pattern as Dockerfile.native)
 RUN apt-get update && \
-    apt-get install -y wget unzip && \
-    wget https://services.gradle.org/distributions/gradle-8.14.3-bin.zip -P /tmp && \
-    unzip -d /opt/gradle /tmp/gradle-8.14.3-bin.zip && \
-    ln -s /opt/gradle/gradle-8.14.3/bin/gradle /usr/bin/gradle && \
-    rm -rf /tmp/gradle-8.14.3-bin.zip
+    apt-get install -y --no-install-recommends wget unzip && \
+    wget -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -O /tmp/gradle.zip && \
+    echo "${GRADLE_SHA256}  /tmp/gradle.zip" | sha256sum -c - && \
+    unzip -d /opt/gradle /tmp/gradle.zip && \
+    ln -s "/opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle" /usr/bin/gradle && \
+    rm -f /tmp/gradle.zip
 
 # Copy build files
 COPY build.gradle.kts .
@@ -37,5 +41,9 @@ EXPOSE 8888
 
 # JVM options for containers
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+
+# Run as a non-root numeric UID (matches distroless "nonroot" and the chart's
+# runAsUser). Numeric so Kubernetes runAsNonRoot checks can verify it.
+USER 65532:65532
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -28,7 +28,8 @@ RUN gradle nativeCompile --no-daemon -PnativeStatic
 # ---- Runtime stage ----
 # distroless/base provides glibc only (no JVM, minimal attack surface). The binary
 # is mostly-static (-PnativeStatic) so it needs no libz.so.1 / libstdc++ at runtime.
-FROM gcr.io/distroless/base-debian12
+# :nonroot variant runs as UID 65532 instead of root.
+FROM gcr.io/distroless/base-debian12:nonroot
 
 WORKDIR /app
 COPY --from=builder /app/build/native/nativeCompile/klag /app/klag

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.2"
+version = "0.2.3"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -3,7 +3,7 @@ name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
 version: 0.3.0
-appVersion: "0.2.2"
+appVersion: "0.2.3"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -32,7 +32,7 @@ annotations:
       url: https://github.com/themoah/klag/blob/main/README.md
   artifacthub.io/images: |
     - name: klag
-      image: themoah/klag:0.2.2
+      image: themoah/klag:0.2.3
   artifacthub.io/maintainers: |
     - name: themoah
       email: aviv@dozorets.com

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "0.1.14"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -3,7 +3,7 @@ name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
 version: 0.3.0
-appVersion: "0.1.14"
+appVersion: "0.2.2"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -32,7 +32,7 @@ annotations:
       url: https://github.com/themoah/klag/blob/main/README.md
   artifacthub.io/images: |
     - name: klag
-      image: themoah/klag:0.1.14
+      image: themoah/klag:0.2.2
   artifacthub.io/maintainers: |
     - name: themoah
       email: aviv@dozorets.com

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -58,9 +58,10 @@ helm install klag ./charts/klag \
   --set-json 'extraVolumeMounts=[{"name":"shared-certificates","mountPath":"/etc/shared-certificates","readOnly":true}]'
 ```
 
-If the truststore is password-protected, also set `KAFKA_SSL_TRUSTSTORE_PASSWORD`
-(via `--set-json` env injection or by mounting it from a secret) — klag picks it
-up automatically as `ssl.truststore.password`.
+If the truststore is password-protected, set `kafka.sslTruststorePassword`. The chart
+stores it in the chart-managed Kafka Secret and injects it as `KAFKA_SSL_TRUSTSTORE_PASSWORD`
+(mapped by klag to `ssl.truststore.password`). With `kafka.existingSecret`, put the password
+under the `truststore-password` key (configurable via `kafka.secretKeys.truststorePassword`).
 
 ### With OTLP Metrics (Grafana Cloud)
 
@@ -98,7 +99,7 @@ helm install klag ./charts/klag \
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `replicaCount` | Number of replicas | `1` |
+| `replicaCount` | Number of replicas. Klag has no leader election: each replica reports the same metrics, so >1 double-reports with push reporters and duplicates series with Prometheus | `1` |
 | `image.repository` | Image repository | `themoah/klag` |
 | `image.tag` | Image tag (defaults to chart appVersion) | `""` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
@@ -115,8 +116,10 @@ helm install klag ./charts/klag \
 | `kafka.saslMechanism` | SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512) | `""` |
 | `kafka.saslJaasConfig` | JAAS configuration string | `""` |
 | `kafka.sslTruststoreLocation` | Path inside the container to the SSL truststore (emits `KAFKA_SSL_TRUSTSTORE_LOCATION`) | `""` |
+| `kafka.sslTruststorePassword` | Truststore password, stored in the Kafka Secret and injected as `KAFKA_SSL_TRUSTSTORE_PASSWORD` | `""` |
 | `kafka.existingSecret` | Name of existing secret for Kafka credentials | `""` |
 | `kafka.secretKeys.jaasConfig` | Key in secret for JAAS config | `jaas-config` |
+| `kafka.secretKeys.truststorePassword` | Key in secret for the truststore password | `truststore-password` |
 
 Any other `KAFKA_*` env var set on the pod is automatically picked up by klag and mapped to the equivalent Kafka client property (e.g. `KAFKA_SSL_TRUSTSTORE_PASSWORD` → `ssl.truststore.password`).
 
@@ -161,6 +164,16 @@ Set `KLAG_CONFIG_FILE` to the path of an external `application.properties` (typi
 | `app.healthCheckIntervalMs` | Kafka health check interval (ms) | `30000` |
 | `app.useVirtualThreads` | Enable Java 21 virtual threads | `false` |
 
+### MCP Configuration (AI agent endpoint)
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mcp.enabled` | Expose the read-only `/mcp` endpoint (sets `MCP_ENABLED`) | `false` |
+| `mcp.path` | HTTP path of the MCP endpoint | `/mcp` |
+| `mcp.authToken` | Bearer token, stored in a chart-managed Secret and injected as `MCP_AUTH_TOKEN`. Empty = unauthenticated (klag logs a warning) | `""` |
+| `mcp.existingSecret` | Existing secret holding the MCP token | `""` |
+| `mcp.secretKeys.authToken` | Key in secret for the token | `mcp-auth-token` |
+
 ### Logging Configuration
 
 | Parameter | Description | Default |
@@ -200,16 +213,30 @@ Set `KLAG_CONFIG_FILE` to the path of an external `application.properties` (typi
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity rules | `{}` |
 | `podAnnotations` | Pod annotations | `{}` |
-| `podSecurityContext` | Pod security context | `{}` |
-| `securityContext` | Container security context | `{}` |
+| `podSecurityContext` | Pod security context | non-root (UID 65532) + `RuntimeDefault` seccomp |
+| `securityContext` | Container security context | no privilege escalation, read-only root FS, all capabilities dropped |
 | `extraVolumes` | Additional pod-level volumes (e.g., truststore PVC, certs Secret) | `[]` |
 | `extraVolumeMounts` | Additional container volume mounts; pair with `extraVolumes` | `[]` |
+| `extraEnv` | Additional environment variables (verbatim `EnvVar` entries) for settings without first-class values (`HOT_PARTITION_*`, `TIME_LAG_*`, `KAFKA_CHUNK_*`, ...) | `[]` |
+| `extraEnvFrom` | Additional `envFrom` sources (ConfigMap/Secret refs) | `[]` |
+
+The pod always mounts an `emptyDir` at `/tmp` so the JVM and Netty work with the
+default `readOnlyRootFilesystem: true`. Chart-managed Secrets are checksummed into a pod
+annotation, so credential changes roll the Deployment automatically.
+
+### NetworkPolicy Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `networkPolicy.enabled` | Create a NetworkPolicy restricting ingress to the http port | `false` |
+| `networkPolicy.ingressFrom` | Allowed peers (`NetworkPolicyPeer` entries); empty = any peer, http port only | `[]` |
 
 ### ServiceAccount Configuration
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `serviceAccount.create` | Create ServiceAccount | `true` |
+| `serviceAccount.automount` | Mount the Kubernetes API token (klag never calls the API) | `false` |
 | `serviceAccount.name` | ServiceAccount name | `""` |
 | `serviceAccount.annotations` | ServiceAccount annotations | `{}` |
 

--- a/charts/klag/templates/_helpers.tpl
+++ b/charts/klag/templates/_helpers.tpl
@@ -95,10 +95,30 @@ Create the name of the secret for Datadog credentials
 {{- end }}
 
 {{/*
+Create the name of the secret for the MCP auth token
+*/}}
+{{- define "klag.mcpSecretName" -}}
+{{- if .Values.mcp.existingSecret }}
+{{- .Values.mcp.existingSecret }}
+{{- else }}
+{{- include "klag.fullname" . }}-mcp
+{{- end }}
+{{- end }}
+
+{{/*
 Determine if Kafka secret should be created
 */}}
 {{- define "klag.createKafkaSecret" -}}
-{{- if and .Values.kafka.saslJaasConfig (not .Values.kafka.existingSecret) }}
+{{- if and (or .Values.kafka.saslJaasConfig .Values.kafka.sslTruststorePassword) (not .Values.kafka.existingSecret) }}
+{{- true }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine if MCP secret should be created
+*/}}
+{{- define "klag.createMcpSecret" -}}
+{{- if and .Values.mcp.enabled .Values.mcp.authToken (not .Values.mcp.existingSecret) }}
 {{- true }}
 {{- end }}
 {{- end }}

--- a/charts/klag/templates/deployment.yaml
+++ b/charts/klag/templates/deployment.yaml
@@ -11,10 +11,13 @@ spec:
       {{- include "klag.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll pods when chart-managed secrets change so rotated credentials take
+        # effect on upgrade rather than at the next unrelated restart.
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "klag.selectorLabels" . | nindent 8 }}
     spec:
@@ -23,6 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "klag.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -66,6 +70,13 @@ spec:
             {{- if .Values.kafka.sslTruststoreLocation }}
             - name: KAFKA_SSL_TRUSTSTORE_LOCATION
               value: {{ .Values.kafka.sslTruststoreLocation | quote }}
+            {{- end }}
+            {{- if .Values.kafka.sslTruststorePassword }}
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "klag.kafkaSecretName" . }}
+                  key: {{ .Values.kafka.secretKeys.truststorePassword }}
             {{- end }}
             # Metrics configuration
             - name: METRICS_REPORTER
@@ -121,6 +132,22 @@ spec:
               value: {{ .Values.metrics.datadog.site | quote }}
             {{- end }}
             {{- end }}
+            # MCP endpoint configuration
+            {{- if .Values.mcp.enabled }}
+            - name: MCP_ENABLED
+              value: "true"
+            {{- if ne .Values.mcp.path "/mcp" }}
+            - name: MCP_PATH
+              value: {{ .Values.mcp.path | quote }}
+            {{- end }}
+            {{- if or .Values.mcp.authToken .Values.mcp.existingSecret }}
+            - name: MCP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "klag.mcpSecretName" . }}
+                  key: {{ .Values.mcp.secretKeys.authToken }}
+            {{- end }}
+            {{- end }}
             # Logging configuration
             {{- if .Values.logging.level }}
             - name: LOG_LEVEL
@@ -142,20 +169,34 @@ spec:
             - name: LOG_LEVEL_METRICS
               value: {{ .Values.logging.levelMetrics | quote }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            # Additional user-supplied environment variables
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.extraVolumeMounts }}
           volumeMounts:
+            # Writable /tmp: the JVM and Netty need it, and the default securityContext
+            # sets readOnlyRootFilesystem: true.
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.extraVolumes }}
+            {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/klag/templates/networkpolicy.yaml
+++ b/charts/klag/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "klag.fullname" . }}
+  labels:
+    {{- include "klag.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "klag.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+      {{- with .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/klag/templates/secret.yaml
+++ b/charts/klag/templates/secret.yaml
@@ -8,7 +8,12 @@ metadata:
     {{- include "klag.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.kafka.saslJaasConfig }}
   {{ .Values.kafka.secretKeys.jaasConfig }}: {{ .Values.kafka.saslJaasConfig | quote }}
+  {{- end }}
+  {{- if .Values.kafka.sslTruststorePassword }}
+  {{ .Values.kafka.secretKeys.truststorePassword }}: {{ .Values.kafka.sslTruststorePassword | quote }}
+  {{- end }}
 {{- end }}
 {{- if include "klag.createOtlpSecret" . }}
 ---
@@ -38,4 +43,16 @@ stringData:
   {{- if .Values.metrics.datadog.appKey }}
   {{ .Values.metrics.datadog.secretKeys.appKey }}: {{ .Values.metrics.datadog.appKey | quote }}
   {{- end }}
+{{- end }}
+{{- if include "klag.createMcpSecret" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "klag.fullname" . }}-mcp
+  labels:
+    {{- include "klag.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.mcp.secretKeys.authToken }}: {{ .Values.mcp.authToken | quote }}
 {{- end }}

--- a/charts/klag/templates/serviceaccount.yaml
+++ b/charts/klag/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/charts/klag/templates/servicemonitor.yaml
+++ b/charts/klag/templates/servicemonitor.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.serviceMonitor.enabled }}
+{{- if ne .Values.metrics.reporter "prometheus" }}
+{{- fail (printf "serviceMonitor.enabled requires metrics.reporter=prometheus (got %q): the /metrics endpoint is only registered for the prometheus reporter, so Prometheus would scrape a 404" .Values.metrics.reporter) }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/klag/values.yaml
+++ b/charts/klag/values.yaml
@@ -1,6 +1,10 @@
 # Default values for klag.
 # This is a YAML-formatted file.
 
+# Number of replicas. NOTE: klag has no leader election. Each replica independently
+# polls Kafka and reports the same metrics. With push reporters (datadog/otlp) more than
+# one replica double-reports (and double-bills); with prometheus it produces duplicate
+# series differing only by pod. Keep at 1 unless you deduplicate downstream.
 replicaCount: 1
 
 image:
@@ -16,6 +20,9 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Klag never talks to the Kubernetes API, so the chart skips mounting the API token.
+  # Set to true if you attach IRSA/workload-identity annotations that need the projected token.
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -24,16 +31,23 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# Secure-by-default pod/container security contexts. UID 65532 matches the non-root user
+# baked into both the JVM and native (distroless :nonroot) images. readOnlyRootFilesystem
+# works because the chart always mounts an emptyDir at /tmp (JVM + Netty need it).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP
@@ -57,11 +71,17 @@ kafka:
   # Typically combined with extraVolumes/extraVolumeMounts to mount a secret or PVC
   # carrying the JKS/PKCS12 truststore.
   sslTruststoreLocation: ""
+  # Password for the truststore above. Stored in the chart-managed Kafka secret and
+  # injected as KAFKA_SSL_TRUSTSTORE_PASSWORD via secretKeyRef. When using existingSecret,
+  # put the password under secretKeys.truststorePassword in that secret and set any
+  # non-empty placeholder here to enable the env var.
+  sslTruststorePassword: ""
   # Use an existing secret for Kafka credentials instead of creating one
   existingSecret: ""
   # Keys in the existing secret
   secretKeys:
     jaasConfig: "jaas-config"
+    truststorePassword: "truststore-password"
 
 # Metrics configuration
 metrics:
@@ -112,6 +132,19 @@ app:
   healthCheckIntervalMs: 30000
   # Enable Java 21 virtual threads (experimental)
   useVirtualThreads: false
+
+# MCP endpoint for AI agents (read-only; see docs). Disabled by default.
+mcp:
+  enabled: false
+  # HTTP path of the MCP endpoint
+  path: "/mcp"
+  # Bearer token required on every MCP request. Stored in a chart-managed Secret and
+  # injected as MCP_AUTH_TOKEN via secretKeyRef. Empty = unauthenticated (klag logs a warning).
+  authToken: ""
+  # Use an existing secret for the MCP token instead of creating one
+  existingSecret: ""
+  secretKeys:
+    authToken: "mcp-auth-token"
 
 # Logging configuration
 logging:
@@ -171,6 +204,36 @@ extraVolumes: []
 #     mountPath: /etc/shared-certificates
 #     readOnly: true
 extraVolumeMounts: []
+
+# Additional environment variables for the klag container (verbatim EnvVar entries).
+# Escape hatch for settings without first-class values: HOT_PARTITION_*, TIME_LAG_*,
+# KAFKA_CHUNK_*, LAG_TREND_DEADBAND_MSG_PER_SEC, KLAG_CONFIG_FILE, LOG_LEVEL_KAFKA_CLIENT, ...
+# Example:
+#   - name: KAFKA_CHUNK_COUNT
+#     value: "4"
+#   - name: SOME_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+extraEnv: []
+
+# Additional envFrom sources (ConfigMaps/Secrets) for the klag container.
+# Example:
+#   - secretRef:
+#       name: my-kafka-env
+extraEnvFrom: []
+
+# Optional NetworkPolicy restricting ingress to the metrics/health/MCP port.
+networkPolicy:
+  enabled: false
+  # Peers allowed to reach the http port (NetworkPolicyPeer entries). Empty list = allow
+  # from anywhere (still restricted to the http port only).
+  # Example:
+  #   - namespaceSelector:
+  #       matchLabels:
+  #         kubernetes.io/metadata.name: monitoring
+  ingressFrom: []
 
 # Prometheus ServiceMonitor configuration
 serviceMonitor:

--- a/src/main/java/io/github/themoah/klag/KlagLauncher.java
+++ b/src/main/java/io/github/themoah/klag/KlagLauncher.java
@@ -4,6 +4,7 @@ import io.github.themoah.klag.config.VertxConfig;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,9 +15,28 @@ public class KlagLauncher {
 
   private static final Logger log = LoggerFactory.getLogger(KlagLauncher.class);
 
+  private static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
+
   public static void main(String[] args) {
     VertxOptions vertxOptions = VertxConfig.createVertxOptions();
     Vertx vertx = Vertx.vertx(vertxOptions);
+
+    // Unlike io.vertx.core.Launcher, a plain main() registers no shutdown hook. Without
+    // one, SIGTERM (each Kubernetes pod stop / docker stop) exits the JVM without running
+    // MainVerticle.stop(), dropping in-flight metric publishes and skipping the Kafka
+    // admin client / HTTP server teardown.
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      log.info("Shutdown signal received, closing Vert.x");
+      try {
+        vertx.close().toCompletionStage().toCompletableFuture()
+          .get(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        log.info("Shutdown complete");
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (Exception e) {
+        log.warn("Graceful shutdown did not complete cleanly: {}", e.toString());
+      }
+    }, "klag-shutdown"));
 
     DeploymentOptions deploymentOptions = VertxConfig.createDeploymentOptions();
 

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
@@ -176,12 +176,22 @@ public class KafkaClientServiceImpl implements KafkaClientService {
           for (PartitionInfo partition : partitions) {
             TopicPartition tp = new TopicPartition(topic, partition.partition());
 
-            // Get earliest offset and timestamp from TIMESTAMP(0)
-            long logStartOffset = earliestTimestampOffsets.get(tp).getOffset();
-            long logStartTimestamp = earliestTimestampOffsets.get(tp).getTimestamp();
-
+            ListOffsetsResultInfo earliestResult = earliestTimestampOffsets.get(tp);
             ListOffsetsResultInfo maxTimestampResult = maxTimestampOffsets.get(tp);
             ListOffsetsResultInfo latestOffsetResult = latestOffsets.get(tp);
+
+            // The partition list comes from a separate describeTopics call; a partition can
+            // be missing from a listOffsets response (leaderless partition, partition added
+            // mid-call, per-partition broker error). Skip it instead of NPEing the whole topic.
+            if (earliestResult == null || latestOffsetResult == null) {
+              log.warn("Missing listOffsets result for {}-{} (earliest={}, latest={}); skipping partition",
+                topic, partition.partition(), earliestResult != null, latestOffsetResult != null);
+              continue;
+            }
+
+            // Get earliest offset and timestamp from TIMESTAMP(0)
+            long logStartOffset = earliestResult.getOffset();
+            long logStartTimestamp = earliestResult.getTimestamp();
 
             // logEndOffset is ALWAYS the true end-of-log (LATEST). This is the boundary
             // for lag = logEndOffset - committedOffset, throughput, and retention.
@@ -300,7 +310,13 @@ public class KafkaClientServiceImpl implements KafkaClientService {
       .map(listings -> listings.stream()
         .map(listing -> listing.getGroupId())
         .collect(Collectors.toSet()))
-      .onSuccess(groups -> log.info("Listed {} consumer groups", groups.size()))
+      .onSuccess(groups -> {
+        // Prune log-dedup state for groups that no longer exist, otherwise churning
+        // ephemeral group IDs (console-consumer-*, CI runs) leak entries for the
+        // process lifetime.
+        lastMissingByGroup.keySet().retainAll(groups);
+        log.info("Listed {} consumer groups", groups.size());
+      })
       .onFailure(err -> log.error("Failed to list consumer groups", err));
   }
 

--- a/src/main/java/io/github/themoah/klag/mcp/McpHandler.java
+++ b/src/main/java/io/github/themoah/klag/mcp/McpHandler.java
@@ -5,6 +5,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +26,10 @@ public class McpHandler {
   private static final String CONTENT_TYPE_JSON = "application/json";
   private static final String SERVER_NAME = "klag";
 
+  // JSON-RPC tool calls fit well under 1 MB; without a limit Vert.x buffers the
+  // entire body in heap (DEFAULT_BODY_LIMIT = -1).
+  private static final long MAX_BODY_BYTES = 1024 * 1024;
+
   private final McpConfig config;
   private final McpTools tools;
 
@@ -38,8 +44,12 @@ public class McpHandler {
    * @param router the Vert.x router
    */
   public void registerRoutes(Router router) {
+    // Auth runs on its own route ahead of the body handler so klag rejects unauthorized
+    // requests without buffering a single body byte (Vert.x forbids a USER handler before
+    // a BODY handler on the same route); the body limit caps what authorized clients can send.
+    router.post(config.path()).handler(this::checkAuth);
     router.post(config.path())
-      .handler(BodyHandler.create())
+      .handler(BodyHandler.create().setBodyLimit(MAX_BODY_BYTES))
       .handler(this::handlePost)
       .failureHandler(this::handleFailure);
     router.get(config.path()).handler(this::handleGet);
@@ -73,16 +83,19 @@ public class McpHandler {
       .end("{\"error\":\"Method Not Allowed; use POST for JSON-RPC\"}");
   }
 
-  private void handlePost(RoutingContext ctx) {
-    if (!authorized(ctx.request().getHeader("Authorization"))) {
-      ctx.response()
-        .setStatusCode(401)
-        .putHeader("WWW-Authenticate", "Bearer")
-        .putHeader("content-type", CONTENT_TYPE_JSON)
-        .end("{\"error\":\"Unauthorized\"}");
+  private void checkAuth(RoutingContext ctx) {
+    if (authorized(ctx.request().getHeader("Authorization"))) {
+      ctx.next();
       return;
     }
+    ctx.response()
+      .setStatusCode(401)
+      .putHeader("WWW-Authenticate", "Bearer")
+      .putHeader("content-type", CONTENT_TYPE_JSON)
+      .end("{\"error\":\"Unauthorized\"}");
+  }
 
+  private void handlePost(RoutingContext ctx) {
     JsonObject request;
     try {
       request = ctx.body().asJsonObject();
@@ -192,7 +205,10 @@ public class McpHandler {
     if (parts.length != 2 || !parts[0].equalsIgnoreCase("Bearer")) {
       return false;
     }
-    return config.authToken().equals(parts[1]);
+    // Constant-time comparison; String.equals short-circuits and leaks a timing side channel.
+    return MessageDigest.isEqual(
+      config.authToken().getBytes(StandardCharsets.UTF_8),
+      parts[1].getBytes(StandardCharsets.UTF_8));
   }
 
   private static void writeJson(RoutingContext ctx, int status, JsonObject body) {

--- a/src/main/java/io/github/themoah/klag/mcp/McpHandler.java
+++ b/src/main/java/io/github/themoah/klag/mcp/McpHandler.java
@@ -99,8 +99,14 @@ public class McpHandler {
     JsonObject request;
     try {
       request = ctx.body().asJsonObject();
-    } catch (DecodeException | ClassCastException e) {
+    } catch (DecodeException e) {
       writeJson(ctx, 200, McpProtocol.error(null, McpProtocol.PARSE_ERROR, "Invalid JSON"));
+      return;
+    } catch (ClassCastException e) {
+      // Valid JSON but not an object (array/string/number) — most often a JSON-RPC batch,
+      // which this server does not support. Per JSON-RPC 2.0 this is -32600, not -32700.
+      writeJson(ctx, 200, McpProtocol.error(null, McpProtocol.INVALID_REQUEST,
+        "Request must be a single JSON-RPC object (batching not supported)"));
       return;
     }
     if (request == null) {
@@ -134,6 +140,12 @@ public class McpHandler {
    * @return the response, or empty if the message is a notification (no response expected)
    */
   public Optional<JsonObject> dispatch(JsonObject request) {
+    // Must run before the notification check: a message missing both "jsonrpc" and "id"
+    // would otherwise be silently accepted as a notification.
+    if (!"2.0".equals(request.getValue("jsonrpc"))) {
+      return Optional.of(McpProtocol.error(request.getValue("id"),
+        McpProtocol.INVALID_REQUEST, "Missing or invalid jsonrpc version (expected \"2.0\")"));
+    }
     if (McpProtocol.isNotification(request)) {
       // The only notification we expect is notifications/initialized; nothing to return.
       return Optional.empty();

--- a/src/main/java/io/github/themoah/klag/mcp/McpTools.java
+++ b/src/main/java/io/github/themoah/klag/mcp/McpTools.java
@@ -116,7 +116,7 @@ public class McpTools {
     }
     Optional<GroupSnapshot> gs = snap.group(group);
     if (gs.isEmpty()) {
-      return text("Consumer group not found in the latest snapshot: " + group);
+      return error("Consumer group not found in the latest snapshot: " + group);
     }
     GroupSnapshot g = gs.get();
 
@@ -150,6 +150,9 @@ public class McpTools {
 
   private JsonObject findLagging(MetricsSnapshot snap, JsonObject args) {
     String sortBy = args.getValue("sortBy") != null ? String.valueOf(args.getValue("sortBy")) : "lag";
+    if (!sortBy.equals("lag") && !sortBy.equals("velocity") && !sortBy.equals("retention")) {
+      return error("Invalid sortBy: " + sortBy + " (expected one of: lag, velocity, retention)");
+    }
     // Accept any numeric limit (truncating floats); ignore non-numeric junk rather than letting
     // the cast throw. Non-positive or out-of-range values fall back to the default.
     Object limitVal = args.getValue("limit");
@@ -193,7 +196,7 @@ public class McpTools {
     }
     Optional<GroupSnapshot> gs = snap.group(group);
     if (gs.isEmpty()) {
-      return text("Consumer group not found in the latest snapshot: " + group);
+      return error("Consumer group not found in the latest snapshot: " + group);
     }
 
     Diagnosis d = Diagnoser.diagnose(gs.get());

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -62,6 +62,16 @@ public class MetricsCollector {
   private final Map<String, Integer> cachedGroupPartitionCounts = new ConcurrentHashMap<>();
   private final Map<String, Integer> cachedTopicPartitionCounts = new ConcurrentHashMap<>();
 
+  // Per-cycle cache of topic offset futures: N groups consuming the same topic share one
+  // describeTopics + listOffsets round instead of issuing N identical queries per cycle.
+  // Cleared at the start of each cycle; cycles never overlap (in-flight guard below).
+  private final Map<String, Future<List<PartitionOffsets>>> cycleTopicOffsets =
+      new ConcurrentHashMap<>();
+
+  // Guards against overlapping collection cycles when a cycle exceeds the interval
+  // (large clusters, chunk delays). Only touched on the Vert.x event loop.
+  private boolean collectionInFlight;
+
   // Optional snapshot store for the MCP layer. When set, the collector publishes its
   // last cycle into it (best-effort, never affecting collection). Null = MCP disabled.
   private SnapshotStore snapshotStore;
@@ -184,7 +194,14 @@ public class MetricsCollector {
     return reporter.start()
       .compose(v -> collectAndReport())
       .onComplete(ar -> {
-        timerId = vertx.setPeriodic(intervalMs, id -> collectAndReport());
+        timerId = vertx.setPeriodic(intervalMs, id -> {
+          if (collectionInFlight) {
+            log.warn("Skipping collection tick: previous cycle still running "
+              + "(METRICS_INTERVAL_MS={} may be too short for this cluster)", intervalMs);
+            return;
+          }
+          collectAndReport();
+        });
         log.info("Metrics collector started, timer ID: {}", timerId);
       })
       .mapEmpty();
@@ -204,6 +221,8 @@ public class MetricsCollector {
 
   private Future<Void> collectAndReport() {
     log.debug("Collecting lag metrics");
+    collectionInFlight = true;
+    cycleTopicOffsets.clear();
 
     return kafkaClient.listConsumerGroups()
       .compose(groups -> {
@@ -227,7 +246,8 @@ public class MetricsCollector {
 
         return collectAllGroupsParallel(filteredGroups);
       })
-      .onFailure(err -> log.error("Failed to collect lag metrics", err));
+      .onFailure(err -> log.error("Failed to collect lag metrics", err))
+      .onComplete(ar -> collectionInFlight = false);
   }
 
   /**
@@ -378,7 +398,7 @@ public class MetricsCollector {
           vertx, topicChunks, chunkConfig.chunkDelayMs(),
           topicChunk -> {
             List<Future<List<PartitionOffsets>>> offsetFutures = topicChunk.stream()
-              .map(kafkaClient::getLogEndOffsets)
+              .map(this::getLogEndOffsetsCached)
               .collect(Collectors.toList());
 
             return Future.all(offsetFutures)
@@ -413,7 +433,12 @@ public class MetricsCollector {
           return buildConsumerGroupLag(groupId, offsets, topicOffsets);
         });
       })
-      .onFailure(err -> log.warn("Failed to collect lag for group {}: {}", groupId, err.getMessage()));
+      // Same recovery as collectGroupLag: a single failed group must not abort the chunk.
+      .recover(err -> {
+        log.warn("Failed to collect lag for group {} (skipped this cycle): {}",
+          groupId, err.getMessage());
+        return Future.succeededFuture(null);
+      });
   }
 
   private Future<List<ConsumerGroupLag>> collectAllGroupLags(Set<String> groups) {
@@ -472,7 +497,7 @@ public class MetricsCollector {
       groupTopicAggregates.forEach((consumerGroup, topicMap) ->
         topicMap.forEach((topic, agg) -> {
           recordVelocitySnapshot(consumerGroup, topic, agg);
-          velocityKeys.add(consumerGroup + ":" + topic);
+          velocityKeys.add(LagVelocityTracker.makeKey(consumerGroup, topic));
         })
       );
 
@@ -560,7 +585,7 @@ public class MetricsCollector {
 
         // Get log end offsets for all topics the group is consuming
         List<Future<List<PartitionOffsets>>> offsetFutures = topics.stream()
-          .map(kafkaClient::getLogEndOffsets)
+          .map(this::getLogEndOffsetsCached)
           .collect(Collectors.toList());
 
         return Future.all(offsetFutures)
@@ -576,7 +601,22 @@ public class MetricsCollector {
             return buildConsumerGroupLag(groupId, offsets, topicOffsets);
           });
       })
-      .onFailure(err -> log.warn("Failed to collect lag for group {}: {}", groupId, err.getMessage()));
+      // Recover to null so one failing group (deleted mid-cycle, coordinator hiccup, ACL gap)
+      // is skipped by the null-filter in collectAllGroupLags instead of failing Future.all
+      // and aborting the whole cycle for every other group.
+      .recover(err -> {
+        log.warn("Failed to collect lag for group {} (skipped this cycle): {}",
+          groupId, err.getMessage());
+        return Future.succeededFuture(null);
+      });
+  }
+
+  /**
+   * Per-cycle cached variant of {@link KafkaClientService#getLogEndOffsets(String)}.
+   * Multiple groups consuming the same topic reuse one in-flight (or completed) future.
+   */
+  private Future<List<PartitionOffsets>> getLogEndOffsetsCached(String topic) {
+    return cycleTopicOffsets.computeIfAbsent(topic, kafkaClient::getLogEndOffsets);
   }
 
   private ConsumerGroupLag buildConsumerGroupLag(
@@ -671,8 +711,10 @@ public class MetricsCollector {
       // Create RetentionRisk for each topic
       for (var entry : topicMaxPercent.entrySet()) {
         risks.add(new RetentionRisk(group.consumerGroup(), entry.getKey(), entry.getValue()));
-        log.debug("Retention risk for {}:{}: {:.2f}%",
-          group.consumerGroup(), entry.getKey(), entry.getValue());
+        if (log.isDebugEnabled()) {
+          log.debug("Retention risk for {}:{}: {}%",
+            group.consumerGroup(), entry.getKey(), String.format("%.2f", entry.getValue()));
+        }
       }
     }
 

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -258,24 +258,14 @@ public class MetricsCollector {
     Future<Map<String, ConsumerGroupState>> stateFuture =
         kafkaClient.describeConsumerGroups(filteredGroups);
 
+    CycleState cycle = new CycleState(newCycleSnapshot());
     return Future.all(lagFuture, stateFuture)
       .map(composite -> {
         List<ConsumerGroupLag> lagData = composite.resultAt(0);
         Map<String, ConsumerGroupState> stateData = composite.resultAt(1);
 
-        Set<String> activeKeys = new HashSet<>();
-        Set<String> velocityKeys = new HashSet<>();
-        Set<String> throughputKeys = new HashSet<>();
-        CycleSnapshot cycleSnapshot = newCycleSnapshot();
-        reportMetrics(lagData, stateData, activeKeys, velocityKeys, throughputKeys, cycleSnapshot);
-        velocityTracker.cleanupStaleTopics(velocityKeys);
-        if (hotPartitionDetector != null && hotPartitionDetector.isEnabled()) {
-          hotPartitionDetector.cleanupStalePartitions(throughputKeys);
-        }
-        if (reporter instanceof MicrometerReporter micrometerReporter) {
-          micrometerReporter.cleanupStaleGauges(activeKeys);
-        }
-        publishSnapshot(cycleSnapshot);
+        reportMetrics(lagData, stateData, cycle);
+        finishCycle(cycle);
         return (Void) null;
       });
   }
@@ -291,38 +281,24 @@ public class MetricsCollector {
       filteredGroups, chunkConfig.chunkCount(),
       group -> cachedGroupPartitionCounts.getOrDefault(group, 1));
 
-    Set<String> cycleActiveKeys = new HashSet<>();
-    Set<String> cycleVelocityKeys = new HashSet<>();
-    Set<String> cycleThroughputKeys = new HashSet<>();
-    CycleSnapshot cycleSnapshot = newCycleSnapshot();
+    CycleState cycle = new CycleState(newCycleSnapshot());
 
     return ChunkProcessor.<String, Void>processSequentially(
       vertx, groupChunks, chunkConfig.chunkDelayMs(),
-      chunk -> processGroupChunk(chunk, cycleActiveKeys, cycleVelocityKeys,
-        cycleThroughputKeys, cycleSnapshot)
+      chunk -> processGroupChunk(chunk, cycle)
     ).compose(results -> {
-      velocityTracker.cleanupStaleTopics(cycleVelocityKeys);
-      if (hotPartitionDetector != null && hotPartitionDetector.isEnabled()) {
-        hotPartitionDetector.cleanupStalePartitions(cycleThroughputKeys);
-      }
-      if (reporter instanceof MicrometerReporter micrometerReporter) {
-        micrometerReporter.cleanupStaleGauges(cycleActiveKeys);
-      }
-      publishSnapshot(cycleSnapshot);
+      finishCycle(cycle);
       return Future.succeededFuture();
     });
   }
 
   /**
    * Processes a single chunk of consumer groups: collects lag, describes groups, reports metrics.
+   *
+   * <p>Recovers on failure so one failed chunk neither aborts the remaining chunks nor fails
+   * the cycle; the cycle is marked partial instead (see {@link #finishCycle(CycleState)}).
    */
-  private Future<Void> processGroupChunk(
-      List<String> chunk,
-      Set<String> cycleActiveKeys,
-      Set<String> cycleVelocityKeys,
-      Set<String> cycleThroughputKeys,
-      CycleSnapshot cycleSnapshot
-  ) {
+  private Future<Void> processGroupChunk(List<String> chunk, CycleState cycle) {
     log.debug("Processing group chunk with {} groups", chunk.size());
 
     Future<List<ConsumerGroupLag>> lagFuture;
@@ -336,21 +312,56 @@ public class MetricsCollector {
         kafkaClient.describeConsumerGroups(new HashSet<>(chunk));
 
     return Future.all(lagFuture, stateFuture)
-      .map(composite -> {
+      .<Void>map(composite -> {
         List<ConsumerGroupLag> lagData = composite.resultAt(0);
         Map<String, ConsumerGroupState> stateData = composite.resultAt(1);
 
-        reportMetrics(lagData, stateData, cycleActiveKeys, cycleVelocityKeys,
-          cycleThroughputKeys, cycleSnapshot);
+        reportMetrics(lagData, stateData, cycle);
 
         // Update cached group partition counts
         for (ConsumerGroupLag lag : lagData) {
           cachedGroupPartitionCounts.put(lag.consumerGroup(), lag.partitions().size());
         }
 
-        return (Void) null;
+        return null;
       })
-      .onFailure(err -> log.warn("Failed to process group chunk: {}", err.getMessage()));
+      .recover(err -> {
+        cycle.partial = true;
+        log.warn("Failed to process group chunk of {} groups (skipped this cycle): {}",
+          chunk.size(), err.getMessage());
+        return Future.succeededFuture(null);
+      });
+  }
+
+  /**
+   * Cycle-end cleanup and snapshot publish, called exactly once per collection cycle.
+   *
+   * <p>All stale-entry cleanups live here (not per chunk) because every cleanup is a
+   * retainAll against the keys observed in the whole cycle: running any of them with a
+   * chunk-local subset wipes the accumulated state of every other chunk.
+   *
+   * <p>Partial cycles (a chunk failed) skip cleanup and publish entirely: the failed
+   * chunk's keys are missing from the accumulators, and cleaning up against an incomplete
+   * key set would mark or delete live series. Stale values beat deleted series.
+   */
+  private void finishCycle(CycleState cycle) {
+    if (cycle.partial) {
+      log.warn("Collection cycle was partial (at least one chunk failed); "
+        + "keeping previous metrics and skipping stale cleanup until a full cycle succeeds");
+      return;
+    }
+    velocityTracker.cleanupStaleTopics(cycle.velocityKeys);
+    if (hotPartitionDetector != null && hotPartitionDetector.isEnabled()) {
+      hotPartitionDetector.cleanupStalePartitions(cycle.throughputKeys);
+    }
+    if (offsetTimestampTracker != null) {
+      offsetTimestampTracker.cleanupStalePartitions(cycle.timeLagKeys);
+    }
+    if (reporter instanceof MicrometerReporter micrometerReporter) {
+      micrometerReporter.cleanupStaleGauges(cycle.activeKeys);
+      micrometerReporter.cleanupStateTracker(cycle.stateGroupKeys);
+    }
+    publishSnapshot(cycle.snapshot);
   }
 
   /**
@@ -461,17 +472,20 @@ public class MetricsCollector {
 
   /**
    * Reports metrics for the given lag and state data.
-   * Adds active gauge keys to the provided set but does NOT perform cleanup.
-   * Velocity and throughput keys are accumulated across chunks for cycle-level cleanup.
+   * Accumulates all observed keys into the cycle state but does NOT perform cleanup:
+   * with chunking this method runs once per chunk, and every cleanup is a retainAll
+   * that must only see the full cycle's keys (see {@link #finishCycle(CycleState)}).
    */
   private void reportMetrics(
       List<ConsumerGroupLag> lagData,
       Map<String, ConsumerGroupState> stateData,
-      Set<String> activeKeys,
-      Set<String> velocityKeys,
-      Set<String> throughputKeys,
-      CycleSnapshot cycleSnapshot
+      CycleState cycle
   ) {
+    Set<String> activeKeys = cycle.activeKeys;
+    Set<String> velocityKeys = cycle.velocityKeys;
+    Set<String> throughputKeys = cycle.throughputKeys;
+    CycleSnapshot cycleSnapshot = cycle.snapshot;
+    cycle.stateGroupKeys.addAll(stateData.keySet());
     if (reporter instanceof MicrometerReporter micrometerReporter) {
       // Report topic partition counts (max partition number + 1)
       Map<String, Integer> topicPartitions = new HashMap<>();
@@ -506,7 +520,7 @@ public class MetricsCollector {
       micrometerReporter.reportVelocity(velocities, activeKeys);
 
       // Calculate lag in ms from timestamps
-      List<LagMs> lagMsData = calculateLagMs(lagData);
+      List<LagMs> lagMsData = calculateLagMs(lagData, cycle.timeLagKeys);
       micrometerReporter.reportLagMs(lagMsData, activeKeys);
 
       // Time-to-close estimation (based on velocity data)
@@ -733,9 +747,12 @@ public class MetricsCollector {
    * timestamps are unavailable; fallback does not extrapolate beyond the oldest retained sample.
    *
    * @param lagData list of consumer group lag data
+   * @param timeLagKeys cycle-level accumulator of tracked "topic:partition" keys; the
+   *     tracker is cleaned against the full cycle's keys in {@link #finishCycle(CycleState)},
+   *     never here, so one chunk cannot wipe another chunk's poll history
    * @return list of lag in milliseconds per consumer group and topic
    */
-  private List<LagMs> calculateLagMs(List<ConsumerGroupLag> lagData) {
+  private List<LagMs> calculateLagMs(List<ConsumerGroupLag> lagData, Set<String> timeLagKeys) {
     if (offsetTimestampTracker == null) {
       return List.of();
     }
@@ -743,12 +760,11 @@ public class MetricsCollector {
     List<LagMs> lagMsList = new ArrayList<>();
     int skippedPartitions = 0;
     long currentTime = System.currentTimeMillis();
-    Set<String> trackedPartitions = new HashSet<>();
 
     for (ConsumerGroupLag group : lagData) {
       for (PartitionLag p : group.partitions()) {
         offsetTimestampTracker.recordOffset(p.topic(), p.partition(), p.logEndOffset());
-        trackedPartitions.add(p.topic() + ":" + p.partition());
+        timeLagKeys.add(p.topic() + ":" + p.partition());
       }
 
       Map<String, TopicLagMsAggregates> topicAggregates = new HashMap<>();
@@ -779,8 +795,6 @@ public class MetricsCollector {
         }
       }
     }
-
-    offsetTimestampTracker.cleanupStalePartitions(trackedPartitions);
 
     if (skippedPartitions > 0) {
       log.debug("Skipped {} partitions with no lag_ms estimate", skippedPartitions);
@@ -823,6 +837,27 @@ public class MetricsCollector {
 
     int count() {
       return count;
+    }
+  }
+
+  /**
+   * Cycle-level accumulators shared by every chunk of one collection cycle.
+   *
+   * <p>Each set gathers the keys observed across all chunks so the retainAll-based
+   * cleanups in {@link #finishCycle(CycleState)} see the complete cycle. {@code partial}
+   * is set when a chunk fails, which suppresses cleanup and snapshot publish for the cycle.
+   */
+  private static class CycleState {
+    final Set<String> activeKeys = new HashSet<>();
+    final Set<String> velocityKeys = new HashSet<>();
+    final Set<String> throughputKeys = new HashSet<>();
+    final Set<String> stateGroupKeys = new HashSet<>();
+    final Set<String> timeLagKeys = new HashSet<>();
+    final CycleSnapshot snapshot; // null when no snapshot store is attached
+    boolean partial;
+
+    CycleState(CycleSnapshot snapshot) {
+      this.snapshot = snapshot;
     }
   }
 

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
@@ -132,7 +132,19 @@ public class MicrometerReporter implements MetricsReporter {
       );
       trackKey(activeKeys, recordGauge("klag.consumer.group.state", tags, changeCount));
     }
-    stateTracker.cleanup(stateData.keySet());
+  }
+
+  /**
+   * Removes state-tracking data for consumer groups that are no longer active.
+   *
+   * <p>Must be called once per collection cycle with the union of all groups observed in
+   * that cycle. Calling it per chunk with a chunk-local subset wipes the state history
+   * (change counts and transitions) of every other chunk's groups.
+   *
+   * @param activeGroupIds all group IDs observed in the completed cycle
+   */
+  public void cleanupStateTracker(Set<String> activeGroupIds) {
+    stateTracker.cleanup(activeGroupIds);
   }
 
   /**

--- a/src/main/java/io/github/themoah/klag/metrics/velocity/LagVelocityTracker.java
+++ b/src/main/java/io/github/themoah/klag/metrics/velocity/LagVelocityTracker.java
@@ -61,8 +61,11 @@ public class LagVelocityTracker {
       LagVelocity velocity = history.calculateVelocity();
       if (velocity != null) {
         velocities.add(velocity);
-        log.debug("Calculated velocity for {}:{}: {:.2f} msg/s ({} samples)",
-          velocity.consumerGroup(), velocity.topic(), velocity.velocity(), velocity.sampleCount());
+        if (log.isDebugEnabled()) {
+          log.debug("Calculated velocity for {}:{}: {} msg/s ({} samples)",
+            velocity.consumerGroup(), velocity.topic(),
+            String.format("%.2f", velocity.velocity()), velocity.sampleCount());
+        }
       }
     }
 
@@ -74,16 +77,21 @@ public class LagVelocityTracker {
    * Follows two-phase deletion pattern similar to MicrometerReporter.
    */
   public void cleanupStaleTopics(Set<String> activeKeys) {
-    Set<String> currentKeys = histories.keySet();
-    currentKeys.retainAll(activeKeys);
+    int before = histories.size();
+    histories.keySet().retainAll(activeKeys);
 
-    int removed = currentKeys.size() - histories.size();
+    int removed = before - histories.size();
     if (removed > 0) {
       log.debug("Cleaned up {} stale topic histories", removed);
     }
   }
 
-  private String makeKey(String consumerGroup, String topic) {
-    return consumerGroup + ":" + topic;
+  /**
+   * Builds the history key for a consumer-group/topic pair. NUL is illegal in topic names
+   * and the topic comes last, so the key decomposes unambiguously even though group IDs
+   * may contain any character (a plain ":" separator collides for group IDs containing ":").
+   */
+  public static String makeKey(String consumerGroup, String topic) {
+    return consumerGroup + '\u0000' + topic;
   }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,8 +15,8 @@
 
   <!-- Package-specific loggers -->
 
-  <!-- Klag application -->
-  <logger name="io.github.themoah.klag" level="${LOG_LEVEL_KLAG:-DEBUG}"/>
+  <!-- Klag application: follows the root level unless LOG_LEVEL_KLAG is set -->
+  <logger name="io.github.themoah.klag" level="${LOG_LEVEL_KLAG:-${LOG_LEVEL:-INFO}}"/>
 
   <!-- Kafka client (health monitor, service) -->
   <logger name="io.github.themoah.klag.kafka" level="${LOG_LEVEL_KAFKA:-INFO}"/>

--- a/src/test/java/io/github/themoah/klag/mcp/McpHandlerTest.java
+++ b/src/test/java/io/github/themoah/klag/mcp/McpHandlerTest.java
@@ -89,6 +89,20 @@ class McpHandlerTest {
   }
 
   @Test
+  void missingJsonrpcVersionIsInvalidRequest() {
+    JsonObject req = new JsonObject().put("id", 7).put("method", McpProtocol.PING);
+    JsonObject resp = openHandler().dispatch(req).orElseThrow();
+    assertEquals(McpProtocol.INVALID_REQUEST, resp.getJsonObject("error").getInteger("code"));
+  }
+
+  @Test
+  void wrongJsonrpcVersionIsInvalidRequest() {
+    JsonObject req = new JsonObject().put("jsonrpc", "1.0").put("id", 8).put("method", McpProtocol.PING);
+    JsonObject resp = openHandler().dispatch(req).orElseThrow();
+    assertEquals(McpProtocol.INVALID_REQUEST, resp.getJsonObject("error").getInteger("code"));
+  }
+
+  @Test
   void notificationProducesNoResponse() {
     JsonObject notif = new JsonObject().put("jsonrpc", "2.0").put("method", McpProtocol.INITIALIZED);
     Optional<JsonObject> resp = openHandler().dispatch(notif);

--- a/src/test/java/io/github/themoah/klag/mcp/McpHttpIntegrationTest.java
+++ b/src/test/java/io/github/themoah/klag/mcp/McpHttpIntegrationTest.java
@@ -136,6 +136,26 @@ class McpHttpIntegrationTest {
   }
 
   @Test
+  void batchArrayIsInvalidRequestNotParseError(VertxTestContext ctx) {
+    // A JSON array is valid JSON, so it must not be reported as a -32700 parse error;
+    // batching is unsupported, which is -32600 Invalid Request.
+    deployThen(enabled(null), new SnapshotStore(), ctx, () ->
+      client.request(HttpMethod.POST, port, "localhost", "/mcp")
+        .compose(req -> {
+          req.putHeader("content-type", "application/json");
+          return req.send(Buffer.buffer(
+            "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"},"
+              + "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}]"));
+        })
+        .compose(resp -> resp.body().map(b -> new HttpResult(resp.statusCode(), b)))
+        .onSuccess(r -> ctx.verify(() -> {
+          assertEquals(-32600, r.json().getJsonObject("error").getInteger("code"));
+          ctx.completeNow();
+        }))
+        .onFailure(ctx::failNow));
+  }
+
+  @Test
   void fullToolsCallFlow(VertxTestContext ctx) {
     deployThen(enabled(null), storeWithPayments(), ctx, () ->
       post(null, new JsonObject()

--- a/src/test/java/io/github/themoah/klag/mcp/McpHttpIntegrationTest.java
+++ b/src/test/java/io/github/themoah/klag/mcp/McpHttpIntegrationTest.java
@@ -149,6 +149,8 @@ class McpHttpIntegrationTest {
         })
         .compose(resp -> resp.body().map(b -> new HttpResult(resp.statusCode(), b)))
         .onSuccess(r -> ctx.verify(() -> {
+          // JSON-RPC errors ride on HTTP 200; only the envelope carries the failure.
+          assertEquals(200, r.status());
           assertEquals(-32600, r.json().getJsonObject("error").getInteger("code"));
           ctx.completeNow();
         }))

--- a/src/test/java/io/github/themoah/klag/mcp/McpToolsTest.java
+++ b/src/test/java/io/github/themoah/klag/mcp/McpToolsTest.java
@@ -100,10 +100,18 @@ class McpToolsTest {
   }
 
   @Test
-  void getConsumerGroupLagUnknownGroupIsNotError() {
+  void getConsumerGroupLagUnknownGroupIsError() {
     McpTools tools = new McpTools(storeWith(group("payments", State.STABLE, 50, 1, 5)));
     JsonObject r = tools.call("get_consumer_group_lag", new JsonObject().put("group", "ghost"));
-    assertFalse(r.getBoolean("isError"));
+    assertTrue(r.getBoolean("isError"));
+    assertTrue(textOf(r).toLowerCase(Locale.ROOT).contains("not found"));
+  }
+
+  @Test
+  void diagnoseUnknownGroupIsError() {
+    McpTools tools = new McpTools(storeWith(group("payments", State.STABLE, 50, 1, 5)));
+    JsonObject r = tools.call("diagnose", new JsonObject().put("group", "ghost"));
+    assertTrue(r.getBoolean("isError"));
     assertTrue(textOf(r).toLowerCase(Locale.ROOT).contains("not found"));
   }
 
@@ -171,6 +179,28 @@ class McpToolsTest {
     String text = textOf(tools.call("find_lagging_groups", new JsonObject().put("limit", 1)));
     assertTrue(text.contains("a"));
     assertFalse(text.contains("\"c\""));
+  }
+
+  @Test
+  void findLaggingGroupsRejectsInvalidSortBy() {
+    McpTools tools = new McpTools(storeWith(group("payments", State.STABLE, 50, 1, 5)));
+    JsonObject r = tools.call("find_lagging_groups", new JsonObject().put("sortBy", "bogus"));
+    assertTrue(r.getBoolean("isError"));
+    String text = textOf(r);
+    assertTrue(text.contains("lag") && text.contains("velocity") && text.contains("retention"),
+      "error must name the valid sortBy values: " + text);
+  }
+
+  @Test
+  void findLaggingGroupsSortsByVelocity() {
+    McpTools tools = new McpTools(storeWith(
+      group("slow", State.STABLE, 9000, 1.0, 1),
+      group("fast", State.STABLE, 10, 99.0, 1)));
+
+    JsonObject r = tools.call("find_lagging_groups", new JsonObject().put("sortBy", "velocity"));
+    assertFalse(r.getBoolean("isError"));
+    String text = textOf(r);
+    assertTrue(text.indexOf("fast") < text.indexOf("slow"));
   }
 
   @Test

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorChunkingTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorChunkingTest.java
@@ -1,0 +1,205 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.themoah.klag.kafka.ChunkConfig;
+import io.github.themoah.klag.kafka.KafkaClientService;
+import io.github.themoah.klag.metrics.hotpartition.HotPartitionConfig;
+import io.github.themoah.klag.metrics.timelag.TimeLagConfig;
+import io.github.themoah.klag.metrics.velocity.LagVelocityTracker;
+import io.github.themoah.klag.model.ConsumerGroupOffsets;
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
+import io.github.themoah.klag.model.ConsumerGroupState;
+import io.github.themoah.klag.model.ConsumerGroupState.State;
+import io.github.themoah.klag.model.PartitionInfo;
+import io.github.themoah.klag.model.PartitionOffsets;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies that chunked collection (KAFKA_CHUNK_COUNT > 1) does not let one chunk
+ * invalidate state accumulated by another chunk, and that one failed chunk neither
+ * aborts the remaining chunks nor causes gauges to be deleted.
+ */
+@ExtendWith(VertxExtension.class)
+class MetricsCollectorChunkingTest {
+
+  /**
+   * Stateful fake: offsets advance each cycle (cycle = one listConsumerGroups call),
+   * Kafka message timestamps are always invalid (0) so lag_ms must use the poll-history
+   * fallback, and describeConsumerGroups can be made to fail for selected groups.
+   */
+  private static class ChunkedFakeKafka implements KafkaClientService {
+    final AtomicInteger cycle = new AtomicInteger();
+    final Map<String, String> groupToTopic;
+    final Map<String, Integer> topicPartitions;
+    volatile Map<String, State> states = new HashMap<>();
+    volatile Set<String> failingGroups = Set.of();
+
+    ChunkedFakeKafka(Map<String, String> groupToTopic, Map<String, Integer> topicPartitions) {
+      this.groupToTopic = groupToTopic;
+      this.topicPartitions = topicPartitions;
+      groupToTopic.keySet().forEach(g -> states.put(g, State.STABLE));
+    }
+
+    long logEnd() { return 100L * cycle.get(); }
+
+    // committed lands inside the retained poll-history window from cycle 2 onward
+    // (cycle 1: 50, cycle 2: 100 >= oldest recorded logEnd 100)
+    long committed() { return logEnd() - 50L * cycle.get(); }
+
+    @Override public Future<Set<String>> listConsumerGroups() {
+      cycle.incrementAndGet();
+      return Future.succeededFuture(Set.copyOf(groupToTopic.keySet()));
+    }
+
+    @Override public Future<ConsumerGroupOffsets> getConsumerGroupOffsets(String groupId) {
+      String topic = groupToTopic.get(groupId);
+      Map<TopicPartitionKey, Long> offsets = new HashMap<>();
+      for (int p = 0; p < topicPartitions.get(topic); p++) {
+        offsets.put(new TopicPartitionKey(topic, p), committed());
+      }
+      return Future.succeededFuture(new ConsumerGroupOffsets(groupId, offsets));
+    }
+
+    @Override public Future<List<PartitionOffsets>> getLogEndOffsets(String topic) {
+      List<PartitionOffsets> result = new ArrayList<>();
+      for (int p = 0; p < topicPartitions.get(topic); p++) {
+        // logEndTimestamp=0 and logStartTimestamp=0: Kafka anchors invalid -> fallback path
+        result.add(new PartitionOffsets(topic, p, logEnd(), 0, 0, logEnd(), 0));
+      }
+      return Future.succeededFuture(result);
+    }
+
+    @Override public Future<Map<String, ConsumerGroupState>> describeConsumerGroups(Set<String> groupIds) {
+      for (String id : groupIds) {
+        if (failingGroups.contains(id)) {
+          return Future.failedFuture("injected describeConsumerGroups failure for " + id);
+        }
+      }
+      Map<String, ConsumerGroupState> result = new HashMap<>();
+      groupIds.forEach(id ->
+        result.put(id, new ConsumerGroupState(id, states.getOrDefault(id, State.STABLE))));
+      return Future.succeededFuture(result);
+    }
+
+    @Override public Future<Set<String>> listTopics() { return Future.succeededFuture(Set.of()); }
+    @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return Future.succeededFuture(List.of()); }
+    @Override public Future<String> describeCluster() { return Future.succeededFuture("cluster"); }
+    @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return Future.succeededFuture(Map.of()); }
+    @Override public Future<Void> close() { return Future.succeededFuture(); }
+  }
+
+  private static final Map<String, String> TWO_GROUPS =
+    Map.of("group-a", "topic-a", "group-b", "topic-b");
+
+  private MetricsCollector chunkedCollector(
+      Vertx vertx, KafkaClientService kafka, MicrometerReporter reporter) {
+    return new MetricsCollector(vertx, kafka, reporter, 60_000, "*", "",
+      new LagVelocityTracker(),
+      new HotPartitionConfig(false, 2.0, 3, 3, 20),
+      new TimeLagConfig(true, 100, 60, 180_000),
+      new ChunkConfig(2, 0));
+  }
+
+  @Test
+  void stateChangeHistorySurvivesOtherChunks(Vertx vertx, VertxTestContext ctx) {
+    ChunkedFakeKafka kafka = new ChunkedFakeKafka(TWO_GROUPS,
+      Map.of("topic-a", 1, "topic-b", 1));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry);
+    MetricsCollector collector = chunkedCollector(vertx, kafka, reporter);
+
+    collector.collectOnce()
+      .compose(v -> {
+        Map<String, State> changed = new HashMap<>(kafka.states);
+        changed.put("group-a", State.EMPTY);
+        kafka.states = changed;
+        return collector.collectOnce();
+      })
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        // With per-chunk cleanup, group-b's chunk wipes group-a's state history every
+        // cycle, so the change is treated as a first observation (0) and no transition
+        // is recorded. The correct values: change count 1, one stable->empty transition.
+        Gauge stateGauge = registry.find("klag.consumer.group.state")
+          .tag("consumer_group", "group-a")
+          .tag("state", "empty")
+          .gauge();
+        assertNotNull(stateGauge, "state gauge for group-a/empty must exist");
+        assertEquals(1.0, stateGauge.value(),
+          "state change count must survive the other chunk's cleanup");
+        assertFalse(reporter.recentStateTransitions("group-a").isEmpty(),
+          "transition history must survive the other chunk's cleanup");
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  void lagMsFallbackHistorySurvivesOtherChunks(Vertx vertx, VertxTestContext ctx) {
+    ChunkedFakeKafka kafka = new ChunkedFakeKafka(TWO_GROUPS,
+      Map.of("topic-a", 1, "topic-b", 1));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MetricsCollector collector = chunkedCollector(vertx, kafka, new MicrometerReporter(registry));
+
+    // Fallback interpolation needs 2 poll samples per partition. With per-chunk cleanup
+    // each chunk wipes the other chunk's poll history, so no partition ever has 2 samples
+    // and klag.consumer.lag.ms stays empty for every topic.
+    collector.collectOnce()
+      .compose(v -> collector.collectOnce())
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        for (String group : TWO_GROUPS.keySet()) {
+          assertNotNull(
+            registry.find("klag.consumer.lag.ms").tag("consumer_group", group).gauge(),
+            "lag_ms gauge must exist for " + group + " after two cycles");
+        }
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  void failedChunkDoesNotAbortRemainingChunksOrDeleteGauges(Vertx vertx, VertxTestContext ctx) {
+    // topic-a has 2 partitions so after cycle 1 group-a is the heaviest group and is
+    // deterministically placed (and processed) first; its failure must not stop group-b.
+    ChunkedFakeKafka kafka = new ChunkedFakeKafka(TWO_GROUPS,
+      Map.of("topic-a", 2, "topic-b", 1));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MetricsCollector collector = chunkedCollector(vertx, kafka, new MicrometerReporter(registry));
+
+    collector.collectOnce()
+      .compose(v -> {
+        kafka.failingGroups = Set.of("group-a");
+        return collector.collectOnce(); // cycle 2: group-a's chunk fails
+      })
+      .compose(v -> collector.collectOnce()) // cycle 3: still failing
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        // group-b must have been collected in cycle 3 (lag per partition = 50 * cycle).
+        Gauge lagSumB = registry.find("klag.consumer.lag.sum")
+          .tag("consumer_group", "group-b").gauge();
+        assertNotNull(lagSumB, "group-b lag gauge must exist");
+        assertEquals(150.0, lagSumB.value(),
+          "group-b must still be collected after group-a's chunk fails");
+
+        // group-a's gauges must survive two consecutive failed cycles: a partial cycle
+        // must not delete series (stale beats deleted for monitoring continuity).
+        Gauge lagSumA = registry.find("klag.consumer.lag.sum")
+          .tag("consumer_group", "group-a").gauge();
+        assertNotNull(lagSumA, "group-a gauges must not be deleted on partial cycles");
+        assertEquals(100.0, lagSumA.value(), "group-a keeps its last good value (cycle 1)");
+        ctx.completeNow();
+      })));
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/velocity/LagVelocityTrackerTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/velocity/LagVelocityTrackerTest.java
@@ -139,8 +139,8 @@ public class LagVelocityTrackerTest {
     // Verify we have 2 velocities before cleanup
     assertEquals(2, tracker.calculateVelocities().size());
 
-    // Cleanup, keeping only group1:topic1
-    tracker.cleanupStaleTopics(Set.of("group1:topic1"));
+    // Cleanup, keeping only group1/topic1
+    tracker.cleanupStaleTopics(Set.of(LagVelocityTracker.makeKey("group1", "topic1")));
 
     // After cleanup, only group1:topic1 should remain
     List<LagVelocity> velocities = tracker.calculateVelocities();


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness, security, and configurability of metrics collection, MCP HTTP API, Kafka client interaction, Docker image, and Helm chart for klag, including safer chunked processing, per-cycle caching, and hardened defaults.

New Features:
- Add per-cycle caching of Kafka topic log-end offsets so multiple consumer groups sharing a topic reuse listOffsets calls.
- Introduce an MCP HTTP endpoint configuration block in the Helm chart, wiring it through to container environment variables and optional MCP auth secret.
- Add support for configuring Kafka SSL truststore passwords via Helm values and secrets, mapped into KAFKA_SSL_TRUSTSTORE_PASSWORD.
- Expose extraEnv and extraEnvFrom options in the Helm chart for arbitrary environment variable injection into the klag container.
- Add optional NetworkPolicy generation in the Helm chart to restrict ingress to the klag HTTP port.

Bug Fixes:
- Prevent overlapping metrics collection cycles by tracking in-flight collection and skipping ticks when the previous cycle is still running.
- Ensure chunked metrics collection does not let one chunk’s cleanup wipe state or history accumulated by other chunks, and avoids deleting gauges after partial failures.
- Handle missing listOffsets results for individual Kafka partitions without failing the entire topic, skipping only the problematic partitions instead.
- Correct MCP tools to treat unknown consumer groups and invalid sortBy values as errors rather than successful responses.
- Align ServiceMonitor usage with the Prometheus reporter by failing Helm template rendering if serviceMonitor is enabled with a non-prometheus metrics reporter.
- Ensure JSON-RPC requests without a jsonrpc version, with a wrong version, or using batch arrays are reported as INVALID_REQUEST instead of PARSE_ERROR.

Enhancements:
- Refactor metrics cycle state management into a dedicated CycleState object with centralized cleanup and snapshot publishing.
- Extend metrics cleanup to cover offset timestamp tracking and consumer-group state tracking at cycle end.
- Refine LagVelocityTracker keying scheme to use an unambiguous separator and improve cleanup logging.
- Improve log messages for retention risk and velocity calculations to avoid unnecessary formatting work in non-debug levels.
- Add a graceful Vert.x shutdown hook in KlagLauncher so pod termination runs verticle stop hooks and cleans up Kafka and HTTP resources.
- Make the klag application logger default to the global LOG_LEVEL when LOG_LEVEL_KLAG is not set.
- Prune KafkaClientServiceImpl’s internal group-missing log-deduplication state when groups disappear to avoid unbounded growth.
- Strengthen MCP HTTP handler with request body size limits, pre-body authentication, constant-time token comparison, and clearer error semantics for invalid JSON-RPC.
- Tighten MCP tools’ behavior and test coverage around lag queries, diagnosis, and sorting by velocity or retention.
- Harden the JVM Docker image by checksum-verifying Gradle downloads, minimizing build-time packages, and running the runtime image as a non-root UID matching Helm defaults.

Build:
- Bump the JVM Dockerfile Gradle installation to a parameterized, checksum-verified download and run the container as a non-root numeric user.
- Increment the application version to 0.2.3 and Helm chart version to 0.3.0 to reflect the new capabilities and breaking chart changes.

Deployment:
- Secure the Helm-deployed pods by default with non-root user/group, RuntimeDefault seccomp, no privilege escalation, read-only root filesystem, and an explicit /tmp emptyDir mount.
- Disable service account token automount by default in the Helm chart and propagate the automount flag to both ServiceAccount and Pod spec.
- Add a checksum annotation for chart-managed secrets to the Deployment template so credential rotations trigger rolling updates.
- Introduce an optional NetworkPolicy resource in the Helm chart to control ingress to the klag service.

Documentation:
- Document new Helm values for Kafka truststore password, MCP configuration, extraEnv/extraEnvFrom, NetworkPolicy, hardened security contexts, and serviceAccount automount behavior in values.yaml and README.
- Clarify logging behavior in CLAUDE.md, including LOG_LEVEL_KLAG fallback and consumer group state metric semantics.
- Add extensive comments to Helm values and templates explaining replicaCount implications, security defaults, /tmp mounting, and secret checksum-based pod rollouts.

Tests:
- Add MetricsCollectorChunkingTest to verify chunked collection preserves state across chunks, handles partial failures without aborting cycles, and keeps gauges on partial cycles.
- Extend MCP HTTP integration tests to cover JSON-RPC batch arrays yielding INVALID_REQUEST rather than PARSE_ERROR.
- Add McpHandler tests for missing and incorrect jsonrpc version handling, and McpTools tests for unknown groups, invalid sortBy, and velocity-based sorting.
- Update LagVelocityTracker tests to use the new key generation helper and validate cleanup behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP endpoint configuration for AI-agent integration; flexible env/envFrom injection; NetworkPolicy support; Kafka SSL truststore password handling.

* **Security**
  * Containers run as non-root by default; stricter pod security defaults and serviceAccount automount off; tighter bearer-token auth (constant-time); request size limits and stricter JSON-RPC validation.

* **Bug Fixes**
  * More robust metrics collection (chunking, partial-cycle recovery, stale-key cleanup); safer handling of missing groups and sort validation; improved JSON-RPC error responses.

* **Documentation**
  * Helm chart README and logging/metrics docs clarified.

* **Chores**
  * Version bumped to 0.2.3; improved graceful shutdown; Docker build hardening.

* **Tests**
  * New unit and integration tests for MCP, tools, and chunking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->