### PR TITLE
ci: guard helm chart version consistency

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,8 @@ jobs:
             helm:
               - 'charts/**'
               - 'scripts/test-helm-chart.sh'
+              - 'scripts/check-version-consistency.sh'
+              - 'build.gradle.kts'
 
   test-helm-chart:
     runs-on: ubuntu-latest
@@ -46,6 +48,9 @@ jobs:
 
       - name: Run Helm chart tests
         run: ./scripts/test-helm-chart.sh
+
+      - name: Check version consistency
+        run: ./scripts/check-version-consistency.sh
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Lint chart
         run: helm lint charts/klag
 
+      # Block publishing a chart whose appVersion / image annotation drifted from
+      # the version release.yml actually builds (that drift broke Artifact Hub on
+      # klag:0.1.14). See scripts/check-version-consistency.sh.
+      - name: Check version consistency
+        run: ./scripts/check-version-consistency.sh
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Guards against the Helm chart referencing a Docker image tag the release
+# pipeline never builds.
+#
+# release.yml builds `themoah/klag:<build.gradle.kts version>` on the
+# `klag-<chart version>` tag that chart-releaser cuts. So Chart.yaml `appVersion`
+# AND the `artifacthub.io/images` annotation tag MUST equal the gradle version.
+# When they drifted, a chart was published pointing at `themoah/klag:0.1.14`, an
+# image that was never pushed, and Artifact Hub's security scan failed forever on
+# that stale version. This check fails the build before such a chart is published.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gradle_ver=$(grep -oE '^version = "[^"]+"' build.gradle.kts | sed -E 's/.*"([^"]+)".*/\1/')
+app_ver=$(grep -oE '^appVersion: "[^"]+"' charts/klag/Chart.yaml | sed -E 's/.*"([^"]+)".*/\1/')
+img_tag=$(grep -oE 'image: themoah/klag:[^[:space:]]+' charts/klag/Chart.yaml | sed -E 's/.*://')
+
+fail=0
+if [[ "$app_ver" != "$gradle_ver" ]]; then
+  echo "::error::Chart appVersion ($app_ver) != build.gradle.kts version ($gradle_ver)"
+  fail=1
+fi
+if [[ "$img_tag" != "$gradle_ver" ]]; then
+  echo "::error::artifacthub.io/images tag ($img_tag) != build.gradle.kts version ($gradle_ver)"
+  fail=1
+fi
+if [[ "$fail" -ne 0 ]]; then
+  echo "release.yml builds themoah/klag:$gradle_ver; the chart must reference exactly that tag."
+  exit 1
+fi
+echo "Version consistency OK: gradle=$gradle_ver appVersion=$app_ver image=$img_tag"

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -17,6 +17,15 @@ gradle_ver=$(grep -oE '^version = "[^"]+"' build.gradle.kts | sed -E 's/.*"([^"]
 app_ver=$(grep -oE '^appVersion: "[^"]+"' charts/klag/Chart.yaml | sed -E 's/.*"([^"]+)".*/\1/')
 img_tag=$(grep -oE 'image: themoah/klag:[^[:space:]]+' charts/klag/Chart.yaml | sed -E 's/.*://')
 
+# Empty = grep matched nothing (file moved/reformatted). Without this the later
+# "$a" != "$b" checks pass on "" == "" and report a false OK.
+for v in gradle_ver app_ver img_tag; do
+  if [[ -z "${!v}" ]]; then
+    echo "::error::Could not extract $v — build.gradle.kts / Chart.yaml format changed?"
+    exit 1
+  fi
+done
+
 fail=0
 if [[ "$app_ver" != "$gradle_ver" ]]; then
   echo "::error::Chart appVersion ($app_ver) != build.gradle.kts version ($gradle_ver)"


### PR DESCRIPTION
## Problem

Artifact Hub's security scan emails kept failing:

```
error scanning image themoah/klag:0.1.14: image not found (package klag:0.2.0)
```

Chart versions `0.2.0`/`0.2.1` had `appVersion: 0.1.14` and an `artifacthub.io/images` annotation pointing at `themoah/klag:0.1.14` — an image that was never pushed to Docker Hub. Artifact Hub re-scans every indexed chart version, so it failed on those stale ones forever.

(The dead index entries themselves are removed separately on `gh-pages`.)

## Fix

`scripts/check-version-consistency.sh` asserts:

- Chart `appVersion` == `build.gradle.kts` version
- `artifacthub.io/images` tag == `build.gradle.kts` version

i.e. the chart can only reference the exact image tag `release.yml` builds.

Wired in as:
- **`helm-release.yml`** — gate before `chart-releaser`, blocks publishing a drifted chart.
- **`build-and-push.yml`** — runs in CI on `charts/**` or `build.gradle.kts` changes, catches drift at PR time.

### Why not a registry-existence probe

`release.yml` builds `themoah/klag:<version>` on the `klag-*` tag that `chart-releaser` creates, so the image is pushed *after* the chart publishes. A "does the image exist" check in `helm-release` would race and false-fail on every release. The consistency check has no such race.

## Verification

- Passes on current repo (`gradle=0.2.4 appVersion=0.2.4 image=0.2.4`).
- Fails (exit 1) on a simulated `appVersion: 0.1.14` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce consistency between the Helm chart and Gradle project versioning to prevent publishing charts that reference non-existent Docker image tags.

CI:
- Add a version consistency check step to the helm-release workflow to block releasing drifted Helm charts.
- Extend the build-and-push workflow to run the version consistency check on relevant file changes, catching drift during CI.

Chores:
- Introduce a check-version-consistency script that validates Helm chart appVersion and Artifact Hub image annotation tags against the Gradle project version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflows with an automated version-consistency check across the Gradle project version, Helm chart `appVersion`, and the referenced image tag.
  * Added the same guard to both Helm tests and Helm releases to catch mismatches earlier, reducing release failures and preventing version drift issues that could impact Artifact Hub indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->