### PR TITLE
chore(chart): expose OTLP_STEP_MS via metrics.otlp.stepMs

### DIFF
--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.2.4"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah

--- a/charts/klag/templates/deployment.yaml
+++ b/charts/klag/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: {{ .Values.metrics.otlp.resourceAttributes | quote }}
             {{- end }}
+            {{- if .Values.metrics.otlp.stepMs }}
+            - name: OTLP_STEP_MS
+              value: {{ .Values.metrics.otlp.stepMs | quote }}
+            {{- end }}
             {{- end }}
             # Datadog configuration (when reporter is datadog)
             {{- if eq .Values.metrics.reporter "datadog" }}

--- a/charts/klag/values.yaml
+++ b/charts/klag/values.yaml
@@ -107,6 +107,9 @@ metrics:
     serviceName: "klag"
     # Additional resource attributes (format: key1=value1,key2=value2)
     resourceAttributes: ""
+    # OTLP export interval in milliseconds (maps to OTLP_STEP_MS env var).
+    # Leave empty to fall back to OTEL_METRIC_EXPORT_INTERVAL or the app default (60000).
+    stepMs: ""
     # Use an existing secret for OTLP headers
     existingSecret: ""
     secretKeys:


### PR DESCRIPTION
## Summary
- Adds `metrics.otlp.stepMs` helm value (default empty) that, when set, renders as the `OTLP_STEP_MS` env var on the klag container.
- App already reads `OTLP_STEP_MS` in `src/main/java/io/github/themoah/klag/metrics/MicrometerConfig.java` (priority: `OTLP_STEP_MS` > `OTEL_METRIC_EXPORT_INTERVAL` > 60s default) — this just exposes it through the chart so operators don't have to fork the chart or wrap the deployment to override the OTLP export interval.
- Chart version bumped 0.3.2 → 0.3.3. No `appVersion` change (helm-only surface).
- Behaviour unchanged when `stepMs` is empty: the env var is omitted, so existing deployments fall back to the same defaults.

Verified locally with `helm template`:
- `stepMs=300000` → `OTLP_STEP_MS=300000` rendered on the container.
- `stepMs` unset → no `OTLP_STEP_MS` env var rendered.
- `helm lint` clean; `./scripts/test-helm-chart.sh` 37/37 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose configuration of the OTLP metrics export interval through the Helm chart and bump the chart version.

New Features:
- Add a metrics.otlp.stepMs Helm value that maps to the OTLP_STEP_MS environment variable when set.

Enhancements:
- Document the new OTLP export interval option in values.yaml comments.

Build:
- Bump the klag Helm chart version from 0.3.2 to 0.3.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OTLP metrics export step interval setting to customize metric export timing.

* **Chores**
  * Bumped Helm chart version to 0.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->