### PR TITLE
add support for -Dhttp.port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ src/main/java/io/github/themoah/klag/
 
 **App:** `HTTP_PORT` (8888), `KAFKA_HEALTH_CHECK_INTERVAL_MS` (30000), `VERTX_USE_VIRTUAL_THREADS` (false), `KLAG_CONFIG_FILE` (path to external `application.properties`, optional)
 
-Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAME` → JVM property `-DNAME` → dotted `-Dname.dotted` (e.g. `HTTP_PORT` → `-Dhttp.port`). Lets jar/native users configure via `-D`; env keeps precedence. See `config/Env.java#resolve`.
+Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAME` → JVM property `-DNAME` → dotted `-Dname.dotted` (e.g. `HTTP_PORT` → `-Dhttp.port`). This lets jar/native users configure via `-D`; env keeps precedence. See `config/Env.java#resolve`.
 
 **Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1), `KAFKA_CHUNK_DELAY_MS` (0). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ src/main/java/io/github/themoah/klag/
 
 **App:** `HTTP_PORT` (8888), `KAFKA_HEALTH_CHECK_INTERVAL_MS` (30000), `VERTX_USE_VIRTUAL_THREADS` (false), `KLAG_CONFIG_FILE` (path to external `application.properties`, optional)
 
+Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAME` → JVM property `-DNAME` → dotted `-Dname.dotted` (e.g. `HTTP_PORT` → `-Dhttp.port`). Lets jar/native users configure via `-D`; env keeps precedence. See `config/Env.java#resolve`.
+
 **Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1), `KAFKA_CHUNK_DELAY_MS` (0). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
 
 **Metrics:** `METRICS_REPORTER` (none/prometheus/datadog/otlp), `METRICS_INTERVAL_MS` (60000), `METRICS_GROUP_FILTER` (comma-separated glob patterns, default `*`), `METRICS_GROUP_EXCLUDE` (comma-separated glob patterns, default empty), `METRICS_JVM_ENABLED` (false), `LAG_TREND_DEADBAND_MSG_PER_SEC` (1.0 — STABLE band for the MCP basic lag-trend classifier; |velocity| within the band is STABLE). A group is monitored iff it matches any include segment AND no exclude segment.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,16 @@ most common:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka broker addresses |
+| `HTTP_PORT` | `8888` | HTTP server port (health, metrics, MCP) |
 | `METRICS_REPORTER` | `none` | `prometheus`, `datadog`, or `otlp` |
 | `METRICS_INTERVAL_MS` | `60000` | How often to collect metrics |
 | `METRICS_GROUP_FILTER` | `*` | Comma-separated glob patterns. A group is included if it matches any segment (e.g. `ingest*,categorize*`). |
 | `METRICS_GROUP_EXCLUDE` | _(empty)_ | Comma-separated glob patterns to exclude even if included by the filter (e.g. `debug-*,canary-*,*-shadow`). |
+
+Any variable can also be set as a JVM system property — `-DNAME` or its dotted-lowercase
+form `-Dname.dotted` (e.g. `HTTP_PORT` → `-Dhttp.port=8881`) — useful when running the jar
+or native binary directly. Env vars take precedence. This works on the GraalVM native
+binary too (runtime `-D` flags).
 
 See [CLAUDE.md](CLAUDE.md) for the complete configuration reference.
 

--- a/src/main/java/io/github/themoah/klag/config/Env.java
+++ b/src/main/java/io/github/themoah/klag/config/Env.java
@@ -4,7 +4,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Reads typed values from environment variables with defaults.
+ * Reads typed values from configuration with defaults.
+ * Each key is resolved in order (first non-blank wins): environment variable {@code NAME},
+ * then JVM system property {@code -DNAME}, then dotted-lowercase property {@code -Dname.dotted}
+ * (e.g. {@code HTTP_PORT} -> {@code -Dhttp.port}). This lets jar/native users set config via
+ * {@code -D} flags while env vars (Docker/k8s) keep precedence.
  * A null or blank value yields the default; an unparseable value logs a warning
  * and falls back to the default.
  */
@@ -14,8 +18,23 @@ public final class Env {
 
   private Env() {}
 
-  public static int getInt(String name, int defaultValue) {
+  /**
+   * Resolves a config value from env var, then -DNAME, then -Dname.dotted. Null if none set.
+   */
+  static String resolve(String name) {
     String value = System.getenv(name);
+    if (value != null && !value.isBlank()) {
+      return value;
+    }
+    value = System.getProperty(name);
+    if (value != null && !value.isBlank()) {
+      return value;
+    }
+    return System.getProperty(name.toLowerCase(java.util.Locale.ROOT).replace('_', '.'));
+  }
+
+  public static int getInt(String name, int defaultValue) {
+    String value = resolve(name);
     if (value == null || value.isBlank()) {
       return defaultValue;
     }
@@ -28,7 +47,7 @@ public final class Env {
   }
 
   public static long getLong(String name, long defaultValue) {
-    String value = System.getenv(name);
+    String value = resolve(name);
     if (value == null || value.isBlank()) {
       return defaultValue;
     }
@@ -41,7 +60,7 @@ public final class Env {
   }
 
   public static double getDouble(String name, double defaultValue) {
-    String value = System.getenv(name);
+    String value = resolve(name);
     if (value == null || value.isBlank()) {
       return defaultValue;
     }
@@ -54,7 +73,7 @@ public final class Env {
   }
 
   public static boolean getBool(String name, boolean defaultValue) {
-    String value = System.getenv(name);
+    String value = resolve(name);
     if (value == null || value.isBlank()) {
       return defaultValue;
     }

--- a/src/test/java/io/github/themoah/klag/config/EnvTest.java
+++ b/src/test/java/io/github/themoah/klag/config/EnvTest.java
@@ -1,0 +1,62 @@
+package io.github.themoah.klag.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Env}.
+ *
+ * <p>Env vars can't be set in-process, so these exercise the system-property fallbacks
+ * ({@code -DNAME} and dotted {@code -Dname.dotted}) and precedence. The env-var path stays
+ * highest in {@link Env#resolve} and is unchanged from before.
+ */
+class EnvTest {
+
+  private static final String NAME = "KLAG_TEST_PORT";
+  private static final String DOTTED = "klag.test.port";
+
+  @AfterEach
+  void clearProps() {
+    System.clearProperty(NAME);
+    System.clearProperty(DOTTED);
+  }
+
+  @Test
+  void exactPropertyResolves() {
+    System.setProperty(NAME, "8881");
+    assertEquals(8881, Env.getInt(NAME, 8888));
+  }
+
+  @Test
+  void dottedPropertyResolves() {
+    System.setProperty(DOTTED, "8881");
+    assertEquals(8881, Env.getInt(NAME, 8888));
+  }
+
+  @Test
+  void exactPropertyWinsOverDotted() {
+    System.setProperty(NAME, "1111");
+    System.setProperty(DOTTED, "2222");
+    assertEquals(1111, Env.getInt(NAME, 8888));
+  }
+
+  @Test
+  void absentUsesDefault() {
+    assertEquals(8888, Env.getInt(NAME, 8888));
+  }
+
+  @Test
+  void invalidUsesDefault() {
+    System.setProperty(NAME, "not-a-number");
+    assertEquals(8888, Env.getInt(NAME, 8888));
+  }
+
+  @Test
+  void boolFromProperty() {
+    System.setProperty(DOTTED, "true");
+    assertTrue(Env.getBool(NAME, false));
+  }
+}

--- a/src/test/java/io/github/themoah/klag/config/EnvTest.java
+++ b/src/test/java/io/github/themoah/klag/config/EnvTest.java
@@ -55,6 +55,12 @@ class EnvTest {
   }
 
   @Test
+  void blankUsesDefault() {
+    System.setProperty(NAME, "   ");
+    assertEquals(8888, Env.getInt(NAME, 8888));
+  }
+
+  @Test
   void boolFromProperty() {
     System.setProperty(DOTTED, "true");
     assertTrue(Env.getBool(NAME, false));

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -7,6 +7,12 @@ Klag is configured via `src/main/resources/application.properties`, an external 
 file, or environment variables. Resolution order is **classpath → external file → env
 vars** (env vars win).
 
+Every environment variable below can also be set as a JVM system property — `-DNAME` or
+its dotted-lowercase form `-Dname.dotted` (e.g. `HTTP_PORT` → `-Dhttp.port=8881`). Handy
+when running the jar or [native binary](/deployment/native-image/) directly without
+exporting env vars. Resolution per key: env var → `-DNAME` → `-Dname.dotted`; env vars
+keep precedence.
+
 ## Application
 
 | Variable | Default | Description |

--- a/website/src/content/docs/deployment/native-image.md
+++ b/website/src/content/docs/deployment/native-image.md
@@ -34,6 +34,15 @@ Benchmark startup and memory:
 scripts/benchmark-startup.sh native - build/native/nativeCompile/klag
 ```
 
+Config works like the JVM build: env vars, or JVM system properties via runtime `-D`
+flags. To run several instances on one host, give each a port:
+
+```bash
+./build/native/nativeCompile/klag -Dhttp.port=8881
+```
+
+See the [configuration reference](/configuration/reference/) for all keys.
+
 ## How it's configured
 
 Native config lives in `build.gradle.kts` (the `graalvmNative` block) plus reachability


### PR DESCRIPTION
## Summary by Sourcery

Allow configuration keys to be resolved from environment variables or JVM system properties, enabling -D-style overrides (including dotted lowercase forms) across Env-backed settings.

New Features:
- Support configuring Env-backed settings via JVM system properties, including both -DNAME and dotted lowercase -Dname.dotted forms (e.g. HTTP_PORT via -Dhttp.port).

Enhancements:
- Unify configuration resolution logic in Env through a shared resolve helper that enforces env-var-over-system-property precedence.

Documentation:
- Document system-property-based configuration for both JVM and native-image builds, including HTTP_PORT/-Dhttp.port usage and resolution precedence in README, configuration reference, and CLAUDE notes.

Tests:
- Add Env unit tests to cover system property and dotted property resolution, precedence, and fallback to defaults for invalid or missing values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated configuration resolution so values can come from environment variables or JVM system properties, using precedence: environment variable `NAME` → `-DNAME` → dotted `-Dname.dotted`.
  * Typed config reads now honor this shared lookup behavior, including defaulting when values are missing/blank/unparseable.

* **Documentation**
  * Expanded configuration docs with `HTTP_PORT` and clarified runtime setup (including native binaries) and how to run multiple instances via different `http.port` values.

* **Tests**
  * Added tests covering system property resolution, precedence, defaults, and boolean parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->