### PR TITLE
Deps/security bump astro undici

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.4"
+version = "0.2.5"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -3,7 +3,7 @@ name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
 version: 0.3.3
-appVersion: "0.2.4"
+appVersion: "0.2.5"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -32,7 +32,7 @@ annotations:
       url: https://github.com/themoah/klag/blob/main/README.md
   artifacthub.io/images: |
     - name: klag
-      image: themoah/klag:0.2.4
+      image: themoah/klag:0.2.5
   artifacthub.io/maintainers: |
     - name: themoah
       email: aviv@dozorets.com

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/sitemap": "^3.7.3",
         "@astrojs/starlight": "^0.39.3",
-        "astro": "^6.4.4",
+        "astro": "^6.4.6",
         "sharp": "^0.34.0"
       },
       "devDependencies": {
@@ -2220,9 +2220,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.4.tgz",
-      "integrity": "sha512-hVe8tq3lqt/Dr0UyB//yUmQSlHMTU8scTiF/vQddQVahLE4TTaSdH5H0nb7OvRcwo0UmlAO8DWYar4jNaS7H+A==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -6029,9 +6029,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/starlight": "^0.39.3",
-    "astro": "^6.4.4",
+    "astro": "^6.4.6",
     "sharp": "^0.34.0"
   },
   "engines": {
@@ -28,7 +28,7 @@
     "wrangler": "^4.98.0"
   },
   "overrides": {
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "ws": "^8.20.1",
     "esbuild": "^0.28.1"
   }


### PR DESCRIPTION
## Summary by Sourcery

Bump website and project dependencies to newer patch versions for Astro and undici and update the project version.

Build:
- Update Astro dependency and undici override versions in the website package configuration.

Chores:
- Increment the project version from 0.2.4 to 0.2.5 in the Gradle build file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the project and chart application version to **0.2.5**.
  * Updated website dependency versions (including Astro and related overrides) to newer compatible releases.
  * Refreshed the Helm chart image reference to match **0.2.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->