### PR TITLE
add member assignment metrics + migration guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAM
 
 **Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1), `KAFKA_CHUNK_DELAY_MS` (0). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
 
-**Metrics:** `METRICS_REPORTER` (none/prometheus/datadog/otlp), `METRICS_INTERVAL_MS` (60000), `METRICS_GROUP_FILTER` (comma-separated glob patterns, default `*`), `METRICS_GROUP_EXCLUDE` (comma-separated glob patterns, default empty), `METRICS_JVM_ENABLED` (false), `LAG_TREND_DEADBAND_MSG_PER_SEC` (1.0 — STABLE band for the MCP basic lag-trend classifier; |velocity| within the band is STABLE). A group is monitored iff it matches any include segment AND no exclude segment.
+**Metrics:** `METRICS_REPORTER` (none/prometheus/datadog/otlp), `METRICS_INTERVAL_MS` (60000), `METRICS_GROUP_FILTER` (comma-separated glob patterns, default `*`), `METRICS_GROUP_EXCLUDE` (comma-separated glob patterns, default empty), `METRICS_JVM_ENABLED` (false), `CONSUMER_MEMBER_LABELS_ENABLED` (true — tag `klag.consumer.lag` and `klag.consumer.committed_offset` with `member_host`/`consumer_id`/`client_id` for the owning consumer instance; kafka-lag-exporter parity. Empty-string values for unowned partitions; set `false` to drop the labels and cut cardinality), `LAG_TREND_DEADBAND_MSG_PER_SEC` (1.0 — STABLE band for the MCP basic lag-trend classifier; |velocity| within the band is STABLE). A group is monitored iff it matches any include segment AND no exclude segment.
 
 **Hot Partition Detection:**
 - `HOT_PARTITION_ENABLED` (true) - Enable/disable hot partition detection
@@ -179,6 +179,7 @@ Note: `klag.hot_partition` only has `topic` and `partition` tags (throughput is 
 Note: Time-based lag metrics only have `consumer_group` and `topic` tags (per-topic granularity)
 Note: DLP metrics only have `consumer_group` and `topic` tags (per-topic granularity)
 Note: Commit freshness metric only has `consumer_group` and `topic` tags (per-topic granularity)
+Note: when `CONSUMER_MEMBER_LABELS_ENABLED=true` (default), `klag.consumer.lag` (per-partition) and `klag.consumer.committed_offset` also carry `member_host`/`consumer_id`/`client_id` for the owning consumer instance (empty strings when unowned). Partition-level `klag.partition.log_*_offset` stay member-agnostic. Members rotate on rebalance, so these series churn; the two-phase stale-gauge cleanup retires old owners within 1–2 intervals.
 Note: `klag.consumer.group.state` carries the state as a *tag*; on a state change the old-state series survives 1–2 collection intervals (two-phase stale-gauge cleanup), so both states export during that window. Key alerts on the most recent sample rather than series existence.
 
 ## Grafana Dashboard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Note: `klag.hot_partition` only has `topic` and `partition` tags (throughput is 
 Note: Time-based lag metrics only have `consumer_group` and `topic` tags (per-topic granularity)
 Note: DLP metrics only have `consumer_group` and `topic` tags (per-topic granularity)
 Note: Commit freshness metric only has `consumer_group` and `topic` tags (per-topic granularity)
-Note: when `CONSUMER_MEMBER_LABELS_ENABLED=true` (default), `klag.consumer.lag` (per-partition) and `klag.consumer.committed_offset` also carry `member_host`/`consumer_id`/`client_id` for the owning consumer instance (empty strings when unowned). Partition-level `klag.partition.log_*_offset` stay member-agnostic. Members rotate on rebalance, so these series churn; the two-phase stale-gauge cleanup retires old owners within 1–2 intervals.
+Note: when `CONSUMER_MEMBER_LABELS_ENABLED=true` (default), `klag.consumer.lag` (per-partition) and `klag.consumer.committed_offset` also carry `member_host`/`consumer_id`/`client_id` for the owning consumer instance (empty strings when unowned). Partition-level `klag.partition.log_*_offset` metrics stay member-agnostic. Members rotate on rebalance, so these series churn; the two-phase stale-gauge cleanup retires old owners within 1–2 intervals.
 Note: `klag.consumer.group.state` carries the state as a *tag*; on a state change the old-state series survives 1–2 collection intervals (two-phase stale-gauge cleanup), so both states export during that window. Key alerts on the most recent sample rather than series existence.
 
 ## Grafana Dashboard

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Inspired by [kafka-lag-exporter](https://github.com/seglo/kafka-lag-exporter) (archived 2024). Built with Vert.x and Micrometer.
 
+Migrating from kafka-lag-exporter? See the **[migration guide](https://klag.dev/migration)** (metric/label/config mapping + drop-in dashboard tips).
+
 > ### 📖 Documentation lives at **[klag.dev](https://klag.dev)**
 >
 > Full guides — configuration, Kafka ACLs, Helm/Strimzi deployment, integrations,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.5"
+version = "0.2.6"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.3
-appVersion: "0.2.5"
+version: 0.3.4
+appVersion: "0.2.6"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -32,10 +32,12 @@ annotations:
       url: https://github.com/themoah/klag/blob/main/README.md
   artifacthub.io/images: |
     - name: klag
-      image: themoah/klag:0.2.5
+      image: themoah/klag:0.2.6
   artifacthub.io/maintainers: |
     - name: themoah
       email: aviv@dozorets.com
   artifacthub.io/changes: |
     - kind: added
-      description: Consumer commit freshness - klag.consumer.commit.staleness_seconds metric and MCP diagnose stuck-consumer flag (lag > 0 but committed offset frozen)
+      description: Per-consumer-instance member labels (member_host, consumer_id, client_id) on consumer-owned lag metrics for kafka-lag-exporter parity; opt out with CONSUMER_MEMBER_LABELS_ENABLED=false
+    - kind: fixed
+      description: Stale gauges are now actually removed from the registry (key-format mismatch left old series lingering on /metrics)

--- a/src/main/java/io/github/themoah/klag/MainVerticle.java
+++ b/src/main/java/io/github/themoah/klag/MainVerticle.java
@@ -1,6 +1,7 @@
 package io.github.themoah.klag;
 
 import io.github.themoah.klag.config.AppConfig;
+import io.github.themoah.klag.config.Env;
 import io.github.themoah.klag.health.HealthCheckHandler;
 import io.github.themoah.klag.health.KafkaHealthMonitor;
 import io.github.themoah.klag.health.VersionHandler;
@@ -155,7 +156,8 @@ public class MainVerticle extends AbstractVerticle {
     // Load hot partition config
     HotPartitionConfig hotPartitionConfig = HotPartitionConfig.fromEnvironment();
 
-    MicrometerReporter reporter = new MicrometerReporter(registry);
+    boolean memberLabelsEnabled = Env.getBool("CONSUMER_MEMBER_LABELS_ENABLED", true);
+    MicrometerReporter reporter = new MicrometerReporter(registry, memberLabelsEnabled);
     MetricsCollector collector = new MetricsCollector(
       vertx,
       kafkaClientService,

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
@@ -3,6 +3,7 @@ package io.github.themoah.klag.kafka;
 import io.github.themoah.klag.model.ConsumerGroupOffsets;
 import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
 import io.github.themoah.klag.model.ConsumerGroupState;
+import io.github.themoah.klag.model.MemberAssignment;
 import io.github.themoah.klag.model.PartitionInfo;
 import io.github.themoah.klag.model.PartitionOffsets;
 import io.vertx.core.Future;
@@ -335,13 +336,35 @@ public class KafkaClientServiceImpl implements KafkaClientService {
         descriptions.forEach((groupId, description) -> {
           ConsumerGroupState.State state = ConsumerGroupState.State
               .fromKafkaState(description.getState());
-          result.put(groupId, new ConsumerGroupState(groupId, state));
+          result.put(groupId, new ConsumerGroupState(groupId, state, partitionOwners(description)));
           log.debug("Consumer group {} state: {}", groupId, state);
         });
         log.info("Described {} consumer groups", result.size());
         return result;
       })
       .onFailure(err -> log.error("Failed to describe consumer groups", err));
+  }
+
+  // Flattens member assignments into a (topic, partition) -> owning member lookup.
+  // A partition can be owned by at most one member; Empty/Dead groups have no members
+  // and yield an empty map (callers emit empty-string member labels for those).
+  // Package-private for unit testing.
+  static Map<TopicPartitionKey, MemberAssignment> partitionOwners(
+      io.vertx.kafka.admin.ConsumerGroupDescription description) {
+    Map<TopicPartitionKey, MemberAssignment> owners = new HashMap<>();
+    if (description.getMembers() == null) {
+      return owners;
+    }
+    description.getMembers().forEach(member -> {
+      if (member.getAssignment() == null || member.getAssignment().getTopicPartitions() == null) {
+        return;
+      }
+      MemberAssignment owner = new MemberAssignment(
+        member.getHost(), member.getConsumerId(), member.getClientId());
+      member.getAssignment().getTopicPartitions().forEach(tp ->
+        owners.put(new TopicPartitionKey(tp.getTopic(), tp.getPartition()), owner));
+    });
+    return owners;
   }
 
   @Override

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -25,6 +25,7 @@ import io.github.themoah.klag.model.HotPartitionLag;
 import io.github.themoah.klag.model.HotPartitionThroughput;
 import io.github.themoah.klag.model.LagMs;
 import io.github.themoah.klag.model.LagVelocity;
+import io.github.themoah.klag.model.MemberAssignment;
 import io.github.themoah.klag.model.MetricsSnapshot;
 import io.github.themoah.klag.model.MetricsSnapshot.GroupSnapshot;
 import io.github.themoah.klag.model.PartitionOffsets;
@@ -578,9 +579,12 @@ public class MetricsCollector {
       reporter.reportRetentionPercent(retentionRisks, activeKeys);
     }
 
-    // Report lag and state metrics
+    // Report lag and state metrics. Member ownership rides along on stateData (same
+    // describeConsumerGroups call) so consumer-owned lag series can carry member labels.
+    Map<String, Map<TopicPartitionKey, MemberAssignment>> partitionOwners = new HashMap<>();
+    stateData.forEach((group, s) -> partitionOwners.put(group, s.partitionOwners()));
     reporter.reportTopicPartitions(topicPartitions, activeKeys);
-    reporter.reportLag(lagData, activeKeys);
+    reporter.reportLag(lagData, partitionOwners, activeKeys);
     reporter.reportConsumerGroupStates(stateData, activeKeys);
 
     // Hot partition detection and reporting

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
@@ -6,8 +6,10 @@ import io.github.themoah.klag.model.CommitStaleness;
 import io.github.themoah.klag.model.ConsumerGroupState;
 import io.github.themoah.klag.model.HotPartitionLag;
 import io.github.themoah.klag.model.HotPartitionThroughput;
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
 import io.github.themoah.klag.model.LagMs;
 import io.github.themoah.klag.model.LagVelocity;
+import io.github.themoah.klag.model.MemberAssignment;
 import io.github.themoah.klag.model.RetentionRisk;
 import io.github.themoah.klag.model.TimeToCloseEstimate;
 import io.micrometer.core.instrument.Gauge;
@@ -33,12 +35,18 @@ public class MicrometerReporter {
   private static final Logger log = LoggerFactory.getLogger(MicrometerReporter.class);
 
   private final MeterRegistry registry;
+  private final boolean memberLabelsEnabled;
   private final Map<String, AtomicLong> gaugeValues = new ConcurrentHashMap<>();
   private final Set<String> markedForDeletion = ConcurrentHashMap.newKeySet();
   private final ConsumerGroupStateTracker stateTracker = new ConsumerGroupStateTracker();
 
   public MicrometerReporter(MeterRegistry registry) {
+    this(registry, true);
+  }
+
+  public MicrometerReporter(MeterRegistry registry, boolean memberLabelsEnabled) {
     this.registry = registry;
+    this.memberLabelsEnabled = memberLabelsEnabled;
   }
 
   /**
@@ -48,6 +56,21 @@ public class MicrometerReporter {
    * @param activeKeys set to populate with active gauge keys (can be null)
    */
   public Future<Void> reportLag(List<ConsumerGroupLag> lagData, Set<String> activeKeys) {
+    return reportLag(lagData, Map.of(), activeKeys);
+  }
+
+  /**
+   * Reports lag metrics, optionally tagging consumer-owned series with member labels.
+   *
+   * @param lagData the lag data to report
+   * @param owners  per-group (topic,partition) -> owning member; ignored when member labels
+   *                are disabled. Partitions absent from the map get empty-string member labels.
+   * @param activeKeys set to populate with active gauge keys (can be null)
+   */
+  public Future<Void> reportLag(
+      List<ConsumerGroupLag> lagData,
+      Map<String, Map<TopicPartitionKey, MemberAssignment>> owners,
+      Set<String> activeKeys) {
     log.debug("Reporting lag metrics for {} consumer groups", lagData.size());
 
     for (ConsumerGroupLag group : lagData) {
@@ -58,6 +81,9 @@ public class MicrometerReporter {
       trackKey(activeKeys, recordGauge("klag.consumer.lag.max", groupTags, group.maxLag()));
       trackKey(activeKeys, recordGauge("klag.consumer.lag.min", groupTags, group.minLag()));
 
+      Map<TopicPartitionKey, MemberAssignment> groupOwners =
+        owners.getOrDefault(group.consumerGroup(), Map.of());
+
       // Per-partition metrics
       for (PartitionLag p : group.partitions()) {
         Tags partitionTags = Tags.of(
@@ -66,14 +92,30 @@ public class MicrometerReporter {
           "partition", String.valueOf(p.partition())
         );
 
-        trackKey(activeKeys, recordGauge("klag.consumer.lag", partitionTags, p.lag()));
+        // Member labels apply only to consumer-owned series (lag, committed offset) — the
+        // log_end/log_start offsets are partition-level and stay member-agnostic, matching
+        // kafka-lag-exporter's kafka_partition_* metrics.
+        Tags memberTags = memberLabelsEnabled
+          ? partitionTags.and(memberTags(groupOwners.get(new TopicPartitionKey(p.topic(), p.partition()))))
+          : partitionTags;
+
+        trackKey(activeKeys, recordGauge("klag.consumer.lag", memberTags, p.lag()));
         trackKey(activeKeys, recordGauge("klag.partition.log_end_offset", partitionTags, p.logEndOffset()));
         trackKey(activeKeys, recordGauge("klag.partition.log_start_offset", partitionTags, p.logStartOffset()));
-        trackKey(activeKeys, recordGauge("klag.consumer.committed_offset", partitionTags, p.committedOffset()));
+        trackKey(activeKeys, recordGauge("klag.consumer.committed_offset", memberTags, p.committedOffset()));
       }
     }
 
     return Future.succeededFuture();
+  }
+
+  private static Tags memberTags(MemberAssignment owner) {
+    MemberAssignment m = owner != null ? owner : MemberAssignment.UNASSIGNED;
+    return Tags.of(
+      "member_host", m.memberHost(),
+      "consumer_id", m.consumerId(),
+      "client_id", m.clientId()
+    );
   }
 
   private void trackKey(Set<String> activeKeys, String key) {
@@ -377,7 +419,11 @@ public class MicrometerReporter {
     }
   }
 
+  // Must match recordGauge's key exactly. Meter.Id#getTags() returns a List<Tag> whose
+  // toString() puts a space after each comma ("[tag(a=b), tag(c=d)]"), whereas Tags#toString()
+  // does not ("[tag(a=b),tag(c=d)]"). Wrapping in Tags.of() reproduces the recordGauge format,
+  // otherwise stale meters are dropped from gaugeValues but never removed from the registry.
   private String buildMeterKey(Meter meter) {
-    return meter.getId().getName() + meter.getId().getTags().toString();
+    return meter.getId().getName() + Tags.of(meter.getId().getTags()).toString();
   }
 }

--- a/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
+++ b/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
@@ -17,6 +17,11 @@ public record ConsumerGroupState(
   Map<TopicPartitionKey, MemberAssignment> partitionOwners
 ) {
 
+  /** Defensively copies partitionOwners so the record stays immutable. */
+  public ConsumerGroupState {
+    partitionOwners = Map.copyOf(partitionOwners);
+  }
+
   /** Backwards-compatible constructor for callers that don't track member ownership. */
   public ConsumerGroupState(String groupId, State state) {
     this(groupId, state, Map.of());

--- a/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
+++ b/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
@@ -1,15 +1,26 @@
 package io.github.themoah.klag.model;
 
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
+import java.util.Map;
+
 /**
  * Consumer group state information.
  *
  * @param groupId the consumer group ID
  * @param state the current state of the consumer group
+ * @param partitionOwners which member instance currently owns each partition; empty for
+ *                        Empty/Dead groups. Powers the per-instance member labels on lag metrics.
  */
 public record ConsumerGroupState(
   String groupId,
-  State state
+  State state,
+  Map<TopicPartitionKey, MemberAssignment> partitionOwners
 ) {
+
+  /** Backwards-compatible constructor for callers that don't track member ownership. */
+  public ConsumerGroupState(String groupId, State state) {
+    this(groupId, state, Map.of());
+  }
 
   /**
    * Enumeration of possible consumer group states.

--- a/src/main/java/io/github/themoah/klag/model/MemberAssignment.java
+++ b/src/main/java/io/github/themoah/klag/model/MemberAssignment.java
@@ -1,0 +1,18 @@
+package io.github.themoah.klag.model;
+
+/**
+ * Identifies the consumer group member (instance) that currently owns a partition.
+ *
+ * <p>Sourced from Kafka's {@code DescribeConsumerGroups} member assignments. Used to tag
+ * consumer-owned lag metrics with {@code member_host} / {@code consumer_id} / {@code client_id},
+ * mirroring kafka-lag-exporter so a partition's lag can be traced to a specific instance.
+ *
+ * @param memberHost the member host (Kafka {@code MemberDescription.host})
+ * @param consumerId the Kafka member id (Kafka {@code MemberDescription.consumerId})
+ * @param clientId   the client id the consumer set (Kafka {@code MemberDescription.clientId})
+ */
+public record MemberAssignment(String memberHost, String consumerId, String clientId) {
+
+  /** Used for partitions with no current owner (Empty/Dead group): emits empty-string labels. */
+  public static final MemberAssignment UNASSIGNED = new MemberAssignment("", "", "");
+}

--- a/src/main/java/io/github/themoah/klag/model/MemberAssignment.java
+++ b/src/main/java/io/github/themoah/klag/model/MemberAssignment.java
@@ -15,4 +15,12 @@ public record MemberAssignment(String memberHost, String consumerId, String clie
 
   /** Used for partitions with no current owner (Empty/Dead group): emits empty-string labels. */
   public static final MemberAssignment UNASSIGNED = new MemberAssignment("", "", "");
+
+  // Kafka may return null host/consumerId/clientId for some brokers/states; normalize to empty
+  // string so these flow straight into Micrometer Tags (which reject null values) without NPEing.
+  public MemberAssignment {
+    memberHost = memberHost == null ? "" : memberHost;
+    consumerId = consumerId == null ? "" : consumerId;
+    clientId = clientId == null ? "" : clientId;
+  }
 }

--- a/src/test/java/io/github/themoah/klag/kafka/KafkaClientServiceImplMembersTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/KafkaClientServiceImplMembersTest.java
@@ -1,0 +1,57 @@
+package io.github.themoah.klag.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
+import io.github.themoah.klag.model.MemberAssignment;
+import io.vertx.kafka.admin.ConsumerGroupDescription;
+import io.vertx.kafka.admin.MemberDescription;
+import io.vertx.kafka.client.common.TopicPartition;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link KafkaClientServiceImpl#partitionOwners} — flattens Kafka member
+ * assignments into the (topic, partition) -> owning member lookup that drives the
+ * kafka-lag-exporter-parity member labels.
+ */
+class KafkaClientServiceImplMembersTest {
+
+  private static MemberDescription member(String consumerId, String clientId, String host,
+      TopicPartition... tps) {
+    return new MemberDescription(consumerId, clientId, host,
+      new io.vertx.kafka.admin.MemberAssignment(Set.of(tps)));
+  }
+
+  @Test
+  void flattensEachAssignedPartitionToItsOwner() {
+    ConsumerGroupDescription desc = new ConsumerGroupDescription()
+      .setGroupId("payments")
+      .setMembers(List.of(
+        member("c-1", "svc-a", "10.0.0.1",
+          new TopicPartition("orders", 0), new TopicPartition("orders", 1)),
+        member("c-2", "svc-b", "10.0.0.2",
+          new TopicPartition("orders", 2))));
+
+    Map<TopicPartitionKey, MemberAssignment> owners =
+      KafkaClientServiceImpl.partitionOwners(desc);
+
+    assertEquals(3, owners.size());
+    assertEquals(new MemberAssignment("10.0.0.1", "c-1", "svc-a"),
+      owners.get(new TopicPartitionKey("orders", 0)));
+    assertEquals(new MemberAssignment("10.0.0.1", "c-1", "svc-a"),
+      owners.get(new TopicPartitionKey("orders", 1)));
+    assertEquals(new MemberAssignment("10.0.0.2", "c-2", "svc-b"),
+      owners.get(new TopicPartitionKey("orders", 2)));
+  }
+
+  @Test
+  void emptyGroupYieldsEmptyMap() {
+    ConsumerGroupDescription desc = new ConsumerGroupDescription()
+      .setGroupId("idle").setMembers(List.of());
+    assertTrue(KafkaClientServiceImpl.partitionOwners(desc).isEmpty());
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterMemberLabelsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterMemberLabelsTest.java
@@ -52,6 +52,8 @@ class MicrometerReporterMemberLabelsTest {
     // partition-level offsets are NOT member-tagged
     assertNull(registry.find("klag.partition.log_end_offset").tag("member_host", "10.0.0.1").gauge(),
       "log_end_offset must stay member-agnostic");
+    assertNull(registry.find("klag.partition.log_start_offset").tag("member_host", "10.0.0.1").gauge(),
+      "log_start_offset must stay member-agnostic");
   }
 
   @Test

--- a/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterMemberLabelsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterMemberLabelsTest.java
@@ -1,0 +1,109 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.github.themoah.klag.model.ConsumerGroupLag;
+import io.github.themoah.klag.model.ConsumerGroupLag.PartitionLag;
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
+import io.github.themoah.klag.model.MemberAssignment;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the kafka-lag-exporter-parity member labels (member_host / consumer_id / client_id)
+ * on consumer-owned lag series: present and correct when enabled with an owner, empty-string when
+ * unowned, absent when disabled, and that a rebalanced owner retires the old series.
+ */
+class MicrometerReporterMemberLabelsTest {
+
+  private static ConsumerGroupLag oneGroup() {
+    PartitionLag p = PartitionLag.of("orders", 0, 100, 0, 0, 0, 90); // lag = 10
+    return ConsumerGroupLag.fromPartitions("payments", List.of(p));
+  }
+
+  private static Map<String, Map<TopicPartitionKey, MemberAssignment>> owners(MemberAssignment a) {
+    return Map.of("payments", Map.of(new TopicPartitionKey("orders", 0), a));
+  }
+
+  @Test
+  void enabledWithOwnerTagsLagSeriesWithMemberLabels() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry, true);
+
+    reporter.reportLag(List.of(oneGroup()),
+      owners(new MemberAssignment("10.0.0.1", "consumer-1-abc", "svc-payments")), null);
+
+    Gauge lag = registry.find("klag.consumer.lag")
+      .tag("consumer_group", "payments").tag("topic", "orders").tag("partition", "0")
+      .tag("member_host", "10.0.0.1").tag("consumer_id", "consumer-1-abc")
+      .tag("client_id", "svc-payments").gauge();
+    assertNotNull(lag, "lag series must carry member labels when enabled with an owner");
+
+    // committed offset is also consumer-owned -> labelled
+    assertNotNull(registry.find("klag.consumer.committed_offset")
+      .tag("member_host", "10.0.0.1").gauge(), "committed_offset carries member labels");
+
+    // partition-level offsets are NOT member-tagged
+    assertNull(registry.find("klag.partition.log_end_offset").tag("member_host", "10.0.0.1").gauge(),
+      "log_end_offset must stay member-agnostic");
+  }
+
+  @Test
+  void enabledWithoutOwnerEmitsEmptyStringLabels() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry, true);
+
+    reporter.reportLag(List.of(oneGroup()), Map.of(), null); // no owners (Empty group)
+
+    Gauge lag = registry.find("klag.consumer.lag")
+      .tag("member_host", "").tag("consumer_id", "").tag("client_id", "").gauge();
+    assertNotNull(lag, "unowned partition gets stable empty-string member labels");
+  }
+
+  @Test
+  void disabledOmitsMemberLabels() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry, false);
+
+    reporter.reportLag(List.of(oneGroup()),
+      owners(new MemberAssignment("10.0.0.1", "consumer-1-abc", "svc-payments")), null);
+
+    assertNull(registry.find("klag.consumer.lag").tag("member_host", "10.0.0.1").gauge(),
+      "no member_host tag when disabled");
+    assertNotNull(registry.find("klag.consumer.lag")
+      .tag("consumer_group", "payments").tag("topic", "orders").tag("partition", "0").gauge(),
+      "plain lag series still present when disabled");
+  }
+
+  @Test
+  void rebalanceRetiresOldMemberSeriesFromRegistry() {
+    // On owner change the member labels change -> a new gauge key. The old key is absent from
+    // the new cycle's active set and the two-phase sweep must remove it from the registry, not
+    // just the internal map (the key-format bug that left meters lingering on /metrics).
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry, true);
+
+    Set<String> cycle1 = new HashSet<>();
+    reporter.reportLag(List.of(oneGroup()),
+      owners(new MemberAssignment("10.0.0.1", "consumer-1", "svc")), cycle1);
+    reporter.cleanupStaleGauges(cycle1);
+
+    // New owner after rebalance; two more sweeps (mark, then delete) retire the old series.
+    Set<String> cycle2 = new HashSet<>();
+    reporter.reportLag(List.of(oneGroup()),
+      owners(new MemberAssignment("10.0.0.2", "consumer-2", "svc")), cycle2);
+    reporter.cleanupStaleGauges(cycle2);
+    reporter.cleanupStaleGauges(cycle2);
+
+    assertNull(registry.find("klag.consumer.lag").tag("member_host", "10.0.0.1").gauge(),
+      "old owner's series must be removed from the registry after rebalance");
+    assertNotNull(registry.find("klag.consumer.lag").tag("member_host", "10.0.0.2").gauge(),
+      "new owner's series present");
+  }
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -41,6 +41,11 @@ if (cfToken) {
 export default defineConfig({
   site: SITE,
 
+  // Short links for the README and external references.
+  redirects: {
+    '/migration': '/getting-started/migrating-from-kafka-lag-exporter/',
+  },
+
   integrations: [
     starlight({
       title: 'Klag',
@@ -63,6 +68,7 @@ export default defineConfig({
             { label: 'Quick Start', slug: 'getting-started/quick-start' },
             { label: 'Installation', slug: 'getting-started/installation' },
             { label: 'Comparison', slug: 'getting-started/comparison' },
+            { label: 'Migrating from kafka-lag-exporter', slug: 'getting-started/migrating-from-kafka-lag-exporter' },
           ],
         },
         {

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -42,6 +42,7 @@ For SASL/SSL, set `KAFKA_SECURITY_PROTOCOL`, `KAFKA_SASL_MECHANISM`, and
 | `METRICS_GROUP_FILTER` | `*` | Comma-separated glob include patterns. |
 | `METRICS_GROUP_EXCLUDE` | _(empty)_ | Comma-separated glob exclude patterns. |
 | `METRICS_JVM_ENABLED` | `false` | Export JVM metrics. |
+| `CONSUMER_MEMBER_LABELS_ENABLED` | `true` | Tag consumer-owned lag metrics with `member_host` / `consumer_id` / `client_id` (kafka-lag-exporter parity). Set `false` to drop them and reduce cardinality. |
 | `LAG_TREND_DEADBAND_MSG_PER_SEC` | `1.0` | STABLE band for the MCP lag-trend classifier. |
 
 A group is monitored **iff** it matches any include segment **and** no exclude segment.

--- a/website/src/content/docs/getting-started/migrating-from-kafka-lag-exporter.md
+++ b/website/src/content/docs/getting-started/migrating-from-kafka-lag-exporter.md
@@ -1,0 +1,121 @@
+---
+title: Migrating from kafka-lag-exporter
+description: Map kafka-lag-exporter metrics, labels, and configuration to Klag, including drop-in dashboard compatibility and the per-consumer member labels.
+---
+
+[kafka-lag-exporter](https://github.com/seglo/kafka-lag-exporter) was archived in 2024. Klag is a
+maintained, drop-in-shaped replacement: it reads the same data from Kafka (offsets via the Admin
+API, `DESCRIBE`-only) and exposes the same core lag metrics, plus velocity, time-based lag, hot
+partitions, retention/data-loss alerting, and an [MCP endpoint](/ai/mcp/) for AI agents.
+
+This guide maps what you have today to Klag so existing dashboards and alerts keep working with
+minimal edits.
+
+## Metric name mapping
+
+Klag exports through Micrometer; the Prometheus names below are what you scrape (dots become
+underscores). The logical metrics match kafka-lag-exporter one-to-one:
+
+| kafka-lag-exporter | Klag (Prometheus name) | Notes |
+|---|---|---|
+| `kafka_consumergroup_group_lag` | `klag_consumer_lag` | per partition |
+| `kafka_consumergroup_group_lag` (summed) | `klag_consumer_lag_sum` | per group |
+| `kafka_consumergroup_group_max_lag` | `klag_consumer_lag_max` | per group |
+| `kafka_consumergroup_group_offset` | `klag_consumer_committed_offset` | committed offset |
+| `kafka_partition_latest_offset` | `klag_partition_log_end_offset` | partition end |
+| `kafka_partition_earliest_offset` | `klag_partition_log_start_offset` | partition start |
+| `kafka_consumergroup_group_lag_seconds` | `klag_consumer_lag_ms` | **milliseconds**, divide by 1000 |
+| `kafka_consumergroup_group_max_lag_seconds` | `klag_consumer_lag_ms` (max over topics) | see [Time-Based Lag](/metrics/time-based-lag/) |
+| group state (label on lag) | `klag_consumer_group_state` | separate metric; state is a tag |
+
+See the full [Metrics Overview](/metrics/overview/) for everything Klag adds on top.
+
+## Label mapping
+
+The biggest change is the group label name:
+
+| kafka-lag-exporter | Klag |
+|---|---|
+| `group` | `consumer_group` |
+| `topic` | `topic` |
+| `partition` | `partition` |
+| `member_host` | `member_host` |
+| `consumer_id` | `consumer_id` |
+| `client_id` | `client_id` |
+| `state` (on lag) | `state` (on `klag_consumer_group_state`) |
+
+The per-consumer-instance labels — `member_host`, `consumer_id`, `client_id` — are **on by
+default** in Klag and identify which consumer instance owns each partition (the same labels you used
+to trace lag to a specific pod). They ride on `klag_consumer_lag` and `klag_consumer_committed_offset`.
+
+### Keep existing dashboards working
+
+If your Grafana panels and alert rules reference `group=`, add a Prometheus relabel rule to alias
+`consumer_group` → `group` so they keep working unchanged:
+
+```yaml
+scrape_configs:
+  - job_name: klag
+    metric_relabel_configs:
+      - source_labels: [consumer_group]
+        target_label: group
+```
+
+Once dashboards are updated to use `consumer_group`, drop the rule.
+
+## Member labels and cardinality
+
+Member labels multiply series by the number of consumer instances, and a partition's owner changes
+on every rebalance (`consumer_id` rotates per session). Klag retires the old instance's series
+within one or two scrape intervals, so churn is bounded — but on very large clusters the extra
+cardinality adds up. To opt out and keep only `consumer_group` / `topic` / `partition`:
+
+```bash
+CONSUMER_MEMBER_LABELS_ENABLED=false
+```
+
+The partition-level `klag_partition_log_end_offset` / `log_start_offset` metrics never carry member
+labels (they describe the partition, not a consumer), matching kafka-lag-exporter's `kafka_partition_*`.
+
+## Configuration mapping
+
+kafka-lag-exporter is configured with a HOCON `application.conf`; Klag uses environment variables
+(or `-D` JVM properties / an external properties file — see the [Configuration Reference](/configuration/reference/)).
+
+| kafka-lag-exporter (`application.conf`) | Klag |
+|---|---|
+| `kafka-lag-exporter.clusters[].bootstrap-brokers` | `KAFKA_BOOTSTRAP_SERVERS` |
+| `kafka-lag-exporter.poll-interval` | `METRICS_INTERVAL_MS` |
+| `kafka-lag-exporter.client-group-id` / consumer props | `KAFKA_*` (mapped to `kafka.*` AdminClient props) |
+| group whitelist (`group-whitelist`) | `METRICS_GROUP_FILTER` (comma-separated globs) |
+| group blacklist (`group-blacklist`) | `METRICS_GROUP_EXCLUDE` (comma-separated globs) |
+| `port` (Prometheus) | `HTTP_PORT` (scrape at `/metrics`) |
+| reporter selection | `METRICS_REPORTER=prometheus` (also `datadog`, `otlp`) |
+
+A minimal Prometheus setup:
+
+```bash
+KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+METRICS_REPORTER=prometheus
+METRICS_INTERVAL_MS=30000
+```
+
+Klag needs only `DESCRIBE` on groups and topics — see [Kafka ACL Permissions](/kafka/acl-permissions/).
+Deploy on Kubernetes with the [Helm chart](/deployment/kubernetes/).
+
+## Time-based lag is different
+
+kafka-lag-exporter estimates lag-in-time by extrapolating offset/timestamp samples. Klag reports
+`klag_consumer_lag_ms` from Kafka's own log timestamps via interpolation (with a poll-history
+fallback), so it does not extrapolate beyond observed data. It also adds a
+`klag_consumer_lag_time_to_close_seconds` estimate while a group is catching up. See
+[Time-Based Lag](/metrics/time-based-lag/).
+
+## What Klag adds — and what it doesn't
+
+**Adds:** [lag velocity](/metrics/lag-velocity/), [hot partition detection](/metrics/hot-partitions/),
+[data-loss / retention alerting](/metrics/data-loss-prevention/), commit freshness, Datadog and OTLP
+sinks, and a read-only [MCP endpoint](/ai/mcp/).
+
+**Doesn't have:** kafka-lag-exporter had no built-in alerting rules or notifiers, and neither does
+Klag — alert in Prometheus/Grafana on the exported metrics as before.

--- a/website/src/content/docs/metrics/overview.md
+++ b/website/src/content/docs/metrics/overview.md
@@ -20,6 +20,12 @@ All metrics are tagged with `consumer_group`, `topic`, and `partition` where app
 | `klag.topic.partitions` | Partition count per topic. |
 | `klag.consumer.group.state` | Group health: Stable, Rebalancing, Dead, Empty. |
 
+`klag.consumer.lag` (per-partition) and `klag.consumer.committed_offset` also carry
+`member_host`, `consumer_id`, and `client_id` tags identifying the consumer **instance** that
+owns each partition — handy for pinning lag to a specific pod. Unowned partitions (Empty/Dead
+groups) get empty-string values. Disable with `CONSUMER_MEMBER_LABELS_ENABLED=false` to cut
+cardinality. The partition-level `klag.partition.log_*_offset` metrics stay member-agnostic.
+
 ## Hot partitions
 
 Reported **only when statistical outliers exist** (see [Hot Partitions](/metrics/hot-partitions/)):


### PR DESCRIPTION
## Summary by Sourcery

Add per-consumer-instance member labels to lag metrics, wire them from Kafka consumer group assignments through to Micrometer, and document migration guidance from kafka-lag-exporter while fixing stale gauge cleanup and bumping the app/Helm chart version.

New Features:
- Expose member-level ownership information for consumer group partitions via a new MemberAssignment model and attach corresponding labels to consumer-owned lag metrics.
- Add configuration to enable or disable consumer member labels on lag metrics via the CONSUMER_MEMBER_LABELS_ENABLED environment variable.
- Introduce a migration guide and navigation for users moving from kafka-lag-exporter, including metric, label, and configuration mapping.

Bug Fixes:
- Correct gauge key construction so stale meters are fully removed from the Micrometer registry instead of lingering on the metrics endpoint.

Enhancements:
- Plumb partition ownership data from Kafka consumer group descriptions into ConsumerGroupState and metrics reporting to support member-labelled lag series.
- Extend ConsumerGroupState to carry partition owner mappings while keeping a backwards-compatible constructor for existing callers.

Build:
- Bump the core project version to 0.2.6 and update the Helm chart version and container image tag accordingly.

Deployment:
- Update Helm chart metadata and Artifact Hub change log to reflect the new member labels feature and stale gauge cleanup fix.

Documentation:
- Document the new consumer member label behavior and configuration in the metrics and configuration reference docs, README, and contributor guide.
- Add a dedicated migration-from-kafka-lag-exporter guide and short redirect link for external references.

Tests:
- Add unit tests for member-labelled lag metrics, including enabled/disabled behavior, unowned partitions, and rebalance cleanup, plus tests for partition owner extraction from Kafka consumer group descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional consumer-instance identity tags (`member_host`, `consumer_id`, `client_id`) to consumer-owned lag and committed-offset metrics, enabled by default and controllable via `CONSUMER_MEMBER_LABELS_ENABLED=false` to reduce cardinality.
  * Added migration documentation and website navigation for users moving from kafka-lag-exporter.
* **Bug Fixes**
  * Fixed stale metric series cleanup so outdated tagged series are removed correctly after partition ownership changes.
* **Documentation**
  * Updated configuration reference, metrics overview, README, and migration guide to describe new labels, unowned-partition behavior, and the cardinality tradeoff.
* **Chores**
  * Bumped app and Helm chart versions (and updated related release metadata).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->