### PR TITLE
feat(metrics): add partition/topic labels to lag metrics (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ OTEL_RESOURCE_ATTRIBUTES=environment=development,cluster=local
 
 ## Metrics Exposed
 
-- `klag.consumer.lag[.sum/.max/.min]` - Consumer lag (per partition and aggregated)
+- `klag.consumer.lag[.sum/.max/.min]` - Consumer lag: base metric per partition; `.sum/.max/.min` aggregated per `consumer_group`+`topic` (group total via `sum by(consumer_group)(klag_consumer_lag_sum)`)
 - `klag.partition.log_end_offset`, `klag.partition.log_start_offset`
 - `klag.consumer.committed_offset`, `klag.consumer.group.state`
 - `klag.topic.partitions` - Partition count per topic
@@ -169,11 +169,11 @@ OTEL_RESOURCE_ATTRIBUTES=environment=development,cluster=local
 - `klag.hot_partition` - Partition throughput × 100 when statistically high (outlier)
 
 **Time-Based Lag Metrics:**
-- `klag.consumer.lag.ms` - Lag in milliseconds (`lag_ms = currentTime - committedMessageTimestamp`). **Primary:** linear interpolation between Kafka `listOffsets` log start/end timestamps and offsets. **Fallback:** poll-time `(logEndOffset, systemTime)` history when Kafka timestamps are invalid (e.g. `logStartTimestamp=0`); requires 2+ poll intervals and does not extrapolate beyond the oldest retained sample (`TIME_LAG_INTERPOLATION_BUFFER_SIZE`).
+- `klag.consumer.lag.ms` - Lag in milliseconds (`lag_ms = currentTime - committedMessageTimestamp`). **Primary:** linear interpolation between Kafka `listOffsets` log start/end timestamps and offsets. **Fallback:** poll-time `(logEndOffset, systemTime)` history when Kafka timestamps are invalid (e.g. `logStartTimestamp=0`); requires 2+ poll intervals and does not extrapolate beyond the oldest retained sample (`TIME_LAG_INTERPOLATION_BUFFER_SIZE`). Emitted both per-partition (`partition` tag) and as a topic-level aggregate = max across partitions (no `partition` tag); select the rollup with `{partition=""}`, drill down with `{partition!=""}`.
 - `klag.consumer.lag.time_to_close_seconds` - Estimated seconds until lag reaches zero (only when catching up and lag > threshold)
 
 **Data Loss Prevention (DLP) Metrics:**
-- `klag.consumer.lag.retention_percent` - Percentage of retention window consumed by lag (value × 100 for precision); enables alerting before data loss. Formula: `(lag / (logEndOffset - logStartOffset)) * 100`. Value of 100% means data loss has occurred (consumer behind logStartOffset). Excludes empty partitions.
+- `klag.consumer.lag.retention_percent` - Percentage of retention window consumed by lag (value × 100 for precision); enables alerting before data loss. Formula: `(lag / (logEndOffset - logStartOffset)) * 100`. Value of 100% means data loss has occurred (consumer behind logStartOffset). Excludes empty partitions. Emitted both per-partition (`partition` tag) and as a topic-level aggregate = max across partitions (no `partition` tag); same `{partition=""}` / `{partition!=""}` selection as `klag.consumer.lag.ms`.
 
 **Commit Freshness Metrics:**
 - `klag.consumer.commit.staleness_seconds` - Seconds since the committed offset last advanced for a group+topic. Only reported while lag > 0 (a frozen-but-idle consumer is not stuck). High/rising = a wedged consumer with pending work that lag alone misses. Inferred — Kafka exposes no commit timestamp, so this measures time since klag *observed* a commit and resets on klag restart.
@@ -183,8 +183,8 @@ OTEL_RESOURCE_ATTRIBUTES=environment=development,cluster=local
 
 Note: `klag.hot_partition` only has `topic` and `partition` tags (throughput is partition-level, independent of consumers)
 Note: `klag.partition.under_replicated` only has `topic` and `partition` tags (ISR status is partition-level, independent of consumers)
-Note: Time-based lag metrics only have `consumer_group` and `topic` tags (per-topic granularity)
-Note: DLP metrics only have `consumer_group` and `topic` tags (per-topic granularity)
+Note: `klag.consumer.lag.time_to_close_seconds` has only `consumer_group` and `topic` tags (per-topic granularity, trend metric)
+Note: `klag.consumer.lag.ms` and `klag.consumer.lag.retention_percent` have `consumer_group`+`topic` for the aggregate series and additionally `partition` for the per-partition series (aggregate = topic-level max, no `partition` tag; select rollups with `{partition=""}`, per-partition with `{partition!=""}`)
 Note: Commit freshness metric only has `consumer_group` and `topic` tags (per-topic granularity)
 Note: when `CONSUMER_MEMBER_LABELS_ENABLED=true` (default), `klag.consumer.lag` (per-partition) and `klag.consumer.committed_offset` also carry `member_host`/`consumer_id`/`client_id` for the owning consumer instance (empty strings when unowned). Partition-level `klag.partition.log_*_offset` metrics stay member-agnostic. Members rotate on rebalance, so these series churn; the two-phase stale-gauge cleanup retires old owners within 1–2 intervals.
 Note: `klag.consumer.group.state` carries the state as a *tag*; on a state change the old-state series survives 1–2 collection intervals (two-phase stale-gauge cleanup), so both states export during that window. Key alerts on the most recent sample rather than series existence.

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -38,6 +38,10 @@ annotations:
       email: aviv@dozorets.com
   artifacthub.io/changes: |
     - kind: added
+      description: Per-partition breakdown of klag.consumer.lag.ms and klag.consumer.lag.retention_percent (topic-level aggregate kept as the partition-less series; select it with {partition=""}, drill down with {partition!=""})
+    - kind: changed
+      description: klag.consumer.lag.sum/.max/.min now carry a topic label (per consumer_group+topic); the group total is recoverable via sum by(consumer_group)(klag_consumer_lag_sum)
+    - kind: added
       description: ISR (in-sync replica) monitoring - klag.partition.under_replicated flags partitions with fewer in-sync replicas than configured; surfaced in the diagnose MCP tool; opt out with ISR_ENABLED=false
     - kind: added
       description: Per-consumer-instance member labels (member_host, consumer_id, client_id) on consumer-owned lag metrics for kafka-lag-exporter parity; opt out with CONSUMER_MEMBER_LABELS_ENABLED=false

--- a/dashboard/demo-dashboard.json
+++ b/dashboard/demo-dashboard.json
@@ -1285,7 +1285,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "klag_consumer_lag_ms{consumer_group=~\"$consumer_group\", topic=~\"$topic\"}",
+                      "expr": "klag_consumer_lag_ms{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"}",
                       "legendFormat": "{{consumer_group}} - {{topic}}",
                       "range": true
                     },
@@ -1603,7 +1603,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "count(klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\"} > 5000) or vector(0)",
+                      "expr": "count(klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"} > 5000) or vector(0)",
                       "legendFormat": "At Risk",
                       "range": true
                     },
@@ -1690,7 +1690,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\"} / 100",
+                      "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"} / 100",
                       "legendFormat": "{{consumer_group}} - {{topic}}",
                       "range": true
                     },
@@ -1808,7 +1808,7 @@
                     "kind": "DataQuery",
                     "spec": {
                       "editorMode": "code",
-                      "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\"} / 100 > 50",
+                      "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"} / 100 > 50",
                       "legendFormat": "__auto",
                       "instant": true,
                       "format": "table"

--- a/dashboard/klag-grafana-com.json
+++ b/dashboard/klag-grafana-com.json
@@ -1241,7 +1241,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "klag_consumer_lag_ms{consumer_group=~\"$consumer_group\", topic=~\"$topic\"}",
+          "expr": "klag_consumer_lag_ms{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"}",
           "legendFormat": "{{consumer_group}} - {{topic}}",
           "range": true
         }
@@ -1491,7 +1491,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\"} > 5000) or vector(0)",
+          "expr": "count(klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"} > 5000) or vector(0)",
           "legendFormat": "At Risk",
           "range": true
         }
@@ -1593,7 +1593,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\"} / 100",
+          "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"} / 100",
           "legendFormat": "{{consumer_group}} - {{topic}}",
           "range": true
         }
@@ -1697,7 +1697,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\"} / 100 > 50",
+          "expr": "klag_consumer_lag_retention_percent{consumer_group=~\"$consumer_group\", topic=~\"$topic\", partition=\"\"} / 100 > 50",
           "legendFormat": "__auto",
           "instant": true,
           "format": "table"

--- a/src/main/java/io/github/themoah/klag/mcp/McpTools.java
+++ b/src/main/java/io/github/themoah/klag/mcp/McpTools.java
@@ -242,6 +242,10 @@ public class McpTools {
   private static JsonArray lagMsArray(List<LagMs> lagMsList) {
     JsonArray a = new JsonArray();
     for (LagMs l : lagMsList) {
+      // Keep the MCP snapshot per-topic: skip per-partition series (issue #55), emit aggregates only.
+      if (l.partition() != LagMs.AGGREGATE) {
+        continue;
+      }
       a.add(new JsonObject().put("topic", l.topic()).put("lagMs", l.lagMs())
         .put("lagMessages", l.lagMessages()));
     }
@@ -284,6 +288,10 @@ public class McpTools {
   private static JsonArray retentionArray(List<RetentionRisk> risks) {
     JsonArray a = new JsonArray();
     for (RetentionRisk r : risks) {
+      // Keep the MCP snapshot per-topic: skip per-partition series (issue #55), emit aggregates only.
+      if (r.partition() != RetentionRisk.AGGREGATE) {
+        continue;
+      }
       a.add(new JsonObject().put("topic", r.topic()).put("percent", r.percent()));
     }
     return a;

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -765,12 +765,15 @@ public class MetricsCollector {
           percent = (p.lag() / (double) retentionWindow) * 100.0;
         }
 
+        // Per-partition series (issue #55) alongside the topic-level aggregate below.
+        risks.add(new RetentionRisk(group.consumerGroup(), p.topic(), p.partition(), percent));
         topicMaxPercent.merge(p.topic(), percent, Math::max);
       }
 
-      // Create RetentionRisk for each topic
+      // Topic-level aggregate (max across partitions)
       for (var entry : topicMaxPercent.entrySet()) {
-        risks.add(new RetentionRisk(group.consumerGroup(), entry.getKey(), entry.getValue()));
+        risks.add(new RetentionRisk(
+          group.consumerGroup(), entry.getKey(), RetentionRisk.AGGREGATE, entry.getValue()));
         if (log.isDebugEnabled()) {
           log.debug("Retention risk for {}:{}: {}%",
             group.consumerGroup(), entry.getKey(), String.format("%.2f", entry.getValue()));
@@ -859,6 +862,9 @@ public class MetricsCollector {
         var lagMs = LagMsCalculator.estimatePartitionLagMs(p, offsetTimestampTracker, currentTime);
 
         if (lagMs.isPresent()) {
+          // Per-partition series (issue #55) alongside the topic-level aggregate below.
+          lagMsList.add(new LagMs(
+            group.consumerGroup(), p.topic(), p.partition(), p.lag(), lagMs.getAsLong()));
           topicAggregates.computeIfAbsent(p.topic(), k -> new TopicLagMsAggregates())
             .add(lagMs.getAsLong(), p.lag());
           log.trace("Partition {}:{}:{} lag_ms={} (committed={})",
@@ -875,7 +881,8 @@ public class MetricsCollector {
         TopicLagMsAggregates agg = entry.getValue();
 
         if (agg.hasData()) {
-          lagMsList.add(new LagMs(group.consumerGroup(), topic, agg.totalLag(), agg.maxLagMs()));
+          lagMsList.add(new LagMs(
+            group.consumerGroup(), topic, LagMs.AGGREGATE, agg.totalLag(), agg.maxLagMs()));
           log.debug("Lag in ms for {}:{}: {} ms (lag_messages={}, partitions_sampled={})",
             group.consumerGroup(), topic, agg.maxLagMs(), agg.totalLag(), agg.count());
         }

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
@@ -18,6 +18,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.vertx.core.Future;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -75,12 +76,24 @@ public class MicrometerReporter {
     log.debug("Reporting lag metrics for {} consumer groups", lagData.size());
 
     for (ConsumerGroupLag group : lagData) {
-      Tags groupTags = Tags.of("consumer_group", group.consumerGroup());
-
-      // Aggregated lag metrics
-      trackKey(activeKeys, recordGauge("klag.consumer.lag.sum", groupTags, group.totalLag()));
-      trackKey(activeKeys, recordGauge("klag.consumer.lag.max", groupTags, group.maxLag()));
-      trackKey(activeKeys, recordGauge("klag.consumer.lag.min", groupTags, group.minLag()));
+      // Per-topic aggregated lag metrics (issue #55: sum/max/min now carry a topic label).
+      // Group total is recoverable via sum by(consumer_group). Model-level
+      // totalLag()/maxLag()/minLag() stay group-level for MCP and the snapshot.
+      Map<String, long[]> topicAgg = new HashMap<>(); // topic -> [sum, max, min]
+      for (PartitionLag p : group.partitions()) {
+        long[] a = topicAgg.computeIfAbsent(
+          p.topic(), k -> new long[] {0, Long.MIN_VALUE, Long.MAX_VALUE});
+        a[0] += p.lag();
+        a[1] = Math.max(a[1], p.lag());
+        a[2] = Math.min(a[2], p.lag());
+      }
+      for (var e : topicAgg.entrySet()) {
+        Tags topicTags = Tags.of("consumer_group", group.consumerGroup(), "topic", e.getKey());
+        long[] a = e.getValue();
+        trackKey(activeKeys, recordGauge("klag.consumer.lag.sum", topicTags, a[0]));
+        trackKey(activeKeys, recordGauge("klag.consumer.lag.max", topicTags, a[1]));
+        trackKey(activeKeys, recordGauge("klag.consumer.lag.min", topicTags, a[2]));
+      }
 
       Map<TopicPartitionKey, MemberAssignment> groupOwners =
         owners.getOrDefault(group.consumerGroup(), Map.of());
@@ -299,6 +312,10 @@ public class MicrometerReporter {
         "consumer_group", lagMs.consumerGroup(),
         "topic", lagMs.topic()
       );
+      // partition == -1 is the topic-level aggregate: omit the tag so it stays a topic rollup.
+      if (lagMs.partition() >= 0) {
+        tags = tags.and("partition", String.valueOf(lagMs.partition()));
+      }
 
       trackKey(activeKeys, recordGauge("klag.consumer.lag.ms", tags, lagMs.lagMs()));
     }
@@ -339,6 +356,10 @@ public class MicrometerReporter {
         "consumer_group", risk.consumerGroup(),
         "topic", risk.topic()
       );
+      // partition == -1 is the topic-level aggregate: omit the tag so it stays a topic rollup.
+      if (risk.partition() >= 0) {
+        tags = tags.and("partition", String.valueOf(risk.partition()));
+      }
 
       // Store as integer (percent * 100) to preserve 2 decimal places
       long percentScaled = Math.round(risk.percent() * 100);

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
@@ -312,8 +312,8 @@ public class MicrometerReporter {
         "consumer_group", lagMs.consumerGroup(),
         "topic", lagMs.topic()
       );
-      // partition == -1 is the topic-level aggregate: omit the tag so it stays a topic rollup.
-      if (lagMs.partition() >= 0) {
+      // LagMs.AGGREGATE (-1) is the topic-level aggregate: omit the tag so it stays a topic rollup.
+      if (lagMs.partition() != LagMs.AGGREGATE) {
         tags = tags.and("partition", String.valueOf(lagMs.partition()));
       }
 
@@ -356,8 +356,8 @@ public class MicrometerReporter {
         "consumer_group", risk.consumerGroup(),
         "topic", risk.topic()
       );
-      // partition == -1 is the topic-level aggregate: omit the tag so it stays a topic rollup.
-      if (risk.partition() >= 0) {
+      // RetentionRisk.AGGREGATE (-1) is the topic-level aggregate: omit the tag so it stays a topic rollup.
+      if (risk.partition() != RetentionRisk.AGGREGATE) {
         tags = tags.and("partition", String.valueOf(risk.partition()));
       }
 

--- a/src/main/java/io/github/themoah/klag/model/LagMs.java
+++ b/src/main/java/io/github/themoah/klag/model/LagMs.java
@@ -1,17 +1,26 @@
 package io.github.themoah.klag.model;
 
 /**
- * Lag in milliseconds for a consumer group and topic (max across partitions).
+ * Lag in milliseconds for a consumer group and topic (or a single partition).
  * Uses Kafka log start/end timestamps when available; otherwise bounded poll-time estimation.
+ *
+ * <p>{@code partition == -1} marks the topic-level aggregate (max lag_ms across partitions);
+ * a value {@code >= 0} is a single partition's estimate. The reporter omits the {@code partition}
+ * tag for the aggregate so topic rollups and per-partition drill-down coexist under one metric.
  *
  * @param consumerGroup the consumer group ID
  * @param topic the topic name
+ * @param partition the partition, or {@code -1} for the topic-level aggregate
  * @param lagMessages the current lag in messages
  * @param lagMs the lag in milliseconds
  */
 public record LagMs(
   String consumerGroup,
   String topic,
+  int partition,
   long lagMessages,
   long lagMs
-) {}
+) {
+  /** Sentinel partition value marking the topic-level aggregate series. */
+  public static final int AGGREGATE = -1;
+}

--- a/src/main/java/io/github/themoah/klag/model/RetentionRisk.java
+++ b/src/main/java/io/github/themoah/klag/model/RetentionRisk.java
@@ -12,12 +12,21 @@ package io.github.themoah.klag.model;
  *   <li>100% - Data loss has occurred (consumer behind logStartOffset)</li>
  * </ul>
  *
+ * <p>{@code partition == -1} marks the topic-level aggregate (max percent across partitions);
+ * a value {@code >= 0} is a single partition's risk. The reporter omits the {@code partition}
+ * tag for the aggregate so topic rollups and per-partition drill-down coexist under one metric.
+ *
  * @param consumerGroup the consumer group ID
  * @param topic the topic name
+ * @param partition the partition, or {@code -1} for the topic-level aggregate
  * @param percent the retention risk percentage (lag / retention_window * 100)
  */
 public record RetentionRisk(
   String consumerGroup,
   String topic,
+  int partition,
   double percent
-) {}
+) {
+  /** Sentinel partition value marking the topic-level aggregate series. */
+  public static final int AGGREGATE = -1;
+}

--- a/src/test/java/io/github/themoah/klag/mcp/DiagnoserTest.java
+++ b/src/test/java/io/github/themoah/klag/mcp/DiagnoserTest.java
@@ -69,7 +69,7 @@ class DiagnoserTest {
   void dataLossIsCritical() {
     GroupSnapshot g = group("payments", State.STABLE, 9000,
       List.of(), List.of(), List.of(),
-      List.of(new RetentionRisk("payments", "orders", 100.0)),
+      List.of(new RetentionRisk("payments", "orders", RetentionRisk.AGGREGATE, 100.0)),
       List.of());
 
     Diagnosis d = Diagnoser.diagnose(g);
@@ -82,7 +82,7 @@ class DiagnoserTest {
   void approachingRetentionWarns() {
     GroupSnapshot g = group("payments", State.STABLE, 4000,
       List.of(), List.of(), List.of(),
-      List.of(new RetentionRisk("payments", "orders", 85.0)),
+      List.of(new RetentionRisk("payments", "orders", RetentionRisk.AGGREGATE, 85.0)),
       List.of());
 
     Diagnosis d = Diagnoser.diagnose(g);
@@ -176,7 +176,7 @@ class DiagnoserTest {
     GroupSnapshot g = group("payments", State.STABLE, 9000,
       List.of(new LagVelocity("payments", "orders", 99.0, 1000, 3)),
       List.of(), List.of(),
-      List.of(new RetentionRisk("payments", "orders", 100.0)),
+      List.of(new RetentionRisk("payments", "orders", RetentionRisk.AGGREGATE, 100.0)),
       List.of(new HotPartitionLag("payments", "orders", 1, 500, 100, 50, 3.0)));
 
     Diagnosis d = Diagnoser.diagnose(g);

--- a/src/test/java/io/github/themoah/klag/mcp/McpToolsTest.java
+++ b/src/test/java/io/github/themoah/klag/mcp/McpToolsTest.java
@@ -27,7 +27,7 @@ class McpToolsTest {
     return new GroupSnapshot(name, state, lag, lag, 0, List.of(p),
       List.of(new LagVelocity(name, "orders", velocity, 1000, 3)),
       List.of(), List.of(),
-      List.of(new RetentionRisk(name, "orders", retention)),
+      List.of(new RetentionRisk(name, "orders", RetentionRisk.AGGREGATE, retention)),
       List.of());
   }
 

--- a/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterLabelsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterLabelsTest.java
@@ -1,0 +1,111 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.themoah.klag.model.ConsumerGroupLag;
+import io.github.themoah.klag.model.ConsumerGroupLag.PartitionLag;
+import io.github.themoah.klag.model.LagMs;
+import io.github.themoah.klag.model.RetentionRisk;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the issue #55 label additions:
+ * <ul>
+ *   <li>{@code klag.consumer.lag.sum/.max/.min} carry a {@code topic} label (per-group-per-topic).</li>
+ *   <li>{@code klag.consumer.lag.ms} emits both the topic-level aggregate (no {@code partition}
+ *       tag) and per-partition series.</li>
+ *   <li>{@code klag.consumer.lag.retention_percent} does the same.</li>
+ * </ul>
+ */
+class MicrometerReporterLabelsTest {
+
+  /** payments consuming two topics: orders (p0 lag=10, p1 lag=20) and shipments (p0 lag=5). */
+  private static ConsumerGroupLag twoTopicGroup() {
+    return ConsumerGroupLag.fromPartitions("payments", List.of(
+      PartitionLag.of("orders", 0, 100, 0, 0, 0, 90),    // lag 10
+      PartitionLag.of("orders", 1, 100, 0, 0, 0, 80),    // lag 20
+      PartitionLag.of("shipments", 0, 100, 0, 0, 0, 95)  // lag 5
+    ));
+  }
+
+  private static boolean hasTag(Meter m, String key) {
+    return m.getId().getTags().stream().anyMatch(t -> t.getKey().equals(key));
+  }
+
+  @Test
+  void lagSumMaxMinCarryTopicLabel() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry);
+
+    reporter.reportLag(List.of(twoTopicGroup()), null);
+
+    // One series per (group, topic), each tagged with topic.
+    assertEquals(2, registry.find("klag.consumer.lag.sum").gauges().size(),
+      "lag.sum must be emitted per topic");
+    Gauge ordersSum = registry.find("klag.consumer.lag.sum")
+      .tag("consumer_group", "payments").tag("topic", "orders").gauge();
+    assertNotNull(ordersSum, "lag.sum must carry a topic label");
+    assertEquals(30.0, ordersSum.value(), "orders sum = 10 + 20");
+    assertEquals(5.0, registry.find("klag.consumer.lag.sum")
+      .tag("topic", "shipments").gauge().value(), "shipments sum = 5");
+
+    assertEquals(20.0, registry.find("klag.consumer.lag.max")
+      .tag("topic", "orders").gauge().value(), "orders max = 20");
+    assertEquals(10.0, registry.find("klag.consumer.lag.min")
+      .tag("topic", "orders").gauge().value(), "orders min = 10");
+
+    // No group-level (topic-less) aggregate remains.
+    assertTrue(registry.find("klag.consumer.lag.sum").gauges().stream().allMatch(g -> hasTag(g, "topic")),
+      "every lag.sum series must be topic-scoped");
+  }
+
+  @Test
+  void lagMsEmitsAggregateAndPerPartition() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry);
+
+    reporter.reportLagMs(List.of(
+      new LagMs("payments", "orders", LagMs.AGGREGATE, 30, 2000), // topic aggregate
+      new LagMs("payments", "orders", 0, 10, 1500),
+      new LagMs("payments", "orders", 1, 20, 2000)
+    ), null);
+
+    // Per-partition series carry the partition tag.
+    assertNotNull(registry.find("klag.consumer.lag.ms")
+      .tag("topic", "orders").tag("partition", "0").gauge(), "per-partition lag.ms present");
+    assertNotNull(registry.find("klag.consumer.lag.ms")
+      .tag("topic", "orders").tag("partition", "1").gauge(), "per-partition lag.ms present");
+
+    // The aggregate carries no partition tag.
+    long aggregates = registry.find("klag.consumer.lag.ms").gauges().stream()
+      .filter(g -> !hasTag(g, "partition")).count();
+    assertEquals(1, aggregates, "exactly one topic-level lag.ms series without a partition tag");
+  }
+
+  @Test
+  void retentionEmitsAggregateAndPerPartition() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry);
+
+    reporter.reportRetentionPercent(List.of(
+      new RetentionRisk("payments", "orders", RetentionRisk.AGGREGATE, 50.0),
+      new RetentionRisk("payments", "orders", 0, 30.0),
+      new RetentionRisk("payments", "orders", 1, 50.0)
+    ), null);
+
+    assertNotNull(registry.find("klag.consumer.lag.retention_percent")
+      .tag("partition", "1").gauge(), "per-partition retention present");
+    assertNull(registry.find("klag.consumer.lag.retention_percent")
+      .tag("consumer_group", "nope").gauge(), "no spurious series");
+    long aggregates = registry.find("klag.consumer.lag.retention_percent").gauges().stream()
+      .filter(g -> !hasTag(g, "partition")).count();
+    assertEquals(1, aggregates, "exactly one topic-level retention series without a partition tag");
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/snapshot/SnapshotBuilderTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/snapshot/SnapshotBuilderTest.java
@@ -56,9 +56,9 @@ class SnapshotBuilderTest {
   @Test
   void routesPerTopicMetricsToOwningGroup() {
     LagVelocity vel = new LagVelocity("payments", "orders", 5.0, 1000, 3);
-    LagMs lagMs = new LagMs("payments", "orders", 60, 2000);
+    LagMs lagMs = new LagMs("payments", "orders", LagMs.AGGREGATE, 60, 2000);
     TimeToCloseEstimate ttc = new TimeToCloseEstimate("payments", "orders", 60, -2.0, 30, 3);
-    RetentionRisk risk = new RetentionRisk("payments", "orders", 12.5);
+    RetentionRisk risk = new RetentionRisk("payments", "orders", RetentionRisk.AGGREGATE, 12.5);
     HotPartitionLag hot = new HotPartitionLag("payments", "orders", 7, 999, 100, 50, 3.0);
 
     MetricsSnapshot snap = SnapshotBuilder.build(

--- a/website/src/content/docs/getting-started/migrating-from-kafka-lag-exporter.md
+++ b/website/src/content/docs/getting-started/migrating-from-kafka-lag-exporter.md
@@ -19,8 +19,8 @@ underscores). The logical metrics match kafka-lag-exporter one-to-one:
 | kafka-lag-exporter | Klag (Prometheus name) | Notes |
 |---|---|---|
 | `kafka_consumergroup_group_lag` | `klag_consumer_lag` | per partition |
-| `kafka_consumergroup_group_lag` (summed) | `klag_consumer_lag_sum` | per group |
-| `kafka_consumergroup_group_max_lag` | `klag_consumer_lag_max` | per group |
+| `kafka_consumergroup_group_lag` (summed) | `klag_consumer_lag_sum` | per group+topic; group total: `sum by (consumer_group)(klag_consumer_lag_sum)` |
+| `kafka_consumergroup_group_max_lag` | `klag_consumer_lag_max` | per group+topic; group max: `max by (consumer_group)(klag_consumer_lag_max)` |
 | `kafka_consumergroup_group_offset` | `klag_consumer_committed_offset` | committed offset |
 | `kafka_partition_latest_offset` | `klag_partition_log_end_offset` | partition end |
 | `kafka_partition_earliest_offset` | `klag_partition_log_start_offset` | partition start |


### PR DESCRIPTION
- klag.consumer.lag.ms: emit per-partition series (partition tag) alongside the topic-level aggregate (max across partitions, no partition tag)
- klag.consumer.lag.sum/.max/.min: add topic label (per consumer_group+topic); group total recoverable via sum by(consumer_group)
- klag.consumer.lag.retention_percent: same per-partition + aggregate split

Aggregate series omit the partition tag: select rollup with {partition=""}, drill down with {partition!=""}. Sentinel partition=-1 marks the aggregate on the LagMs/RetentionRisk records. MCP snapshot output stays per-topic (filters to aggregate-only). ConsumerGroupLag model untouched (MCP/snapshot still read group-level totalLag/maxLag/minLag).

Docs + dashboard queries updated; no version bump.

## Summary by Sourcery

Add partition and topic labeling to lag-related metrics while keeping MCP and snapshot views topic-level aggregates.

New Features:
- Expose klag.consumer.lag.ms as both per-partition series and topic-level aggregate without a partition label.
- Expose klag.consumer.lag.retention_percent as both per-partition series and topic-level aggregate without a partition label.
- Emit klag.consumer.lag.sum/.max/.min aggregated per consumer_group+topic via a topic label instead of only group-level totals.

Enhancements:
- Introduce partition sentinel values to distinguish topic-level aggregate series in LagMs and RetentionRisk models and preserve existing MCP and snapshot semantics.
- Update documentation, Helm chart metadata, dashboards, and tests to reflect the new metric label schema and ensure correct aggregation and drill-down behavior.

Tests:
- Add MicrometerReporter label tests covering topic-scoped sum/max/min metrics and combined aggregate/per-partition time-lag and retention metrics behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added partition-aware retention risk and lag timing metrics alongside topic-level aggregates, with consistent aggregate-vs-partition labeling.
  * Updated lag sum/max/min gauges to report per-topic aggregates (with topic identifiers).

* **Bug Fixes**
  * Improved Prometheus tagging to clearly separate aggregate series from per-partition series.

* **Documentation**
  * Expanded metric documentation and migration guidance to describe correct label selection and aggregation queries.
  * Refreshed Grafana dashboard panels and chart changelog to filter for the intended aggregate (`partition=""`) views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->