### PR TITLE
Drop Artifact Hub images annotation

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Lint chart
         run: helm lint charts/klag
 
-      # Block publishing a chart whose appVersion / image annotation drifted from
-      # the version release.yml actually builds (that drift broke Artifact Hub on
-      # klag:0.1.14). See scripts/check-version-consistency.sh.
+      # Block publishing a chart whose appVersion drifted from the version
+      # release.yml actually builds (that drift broke Artifact Hub when a chart
+      # pointed at themoah/klag:0.1.14). See scripts/check-version-consistency.sh.
       - name: Check version consistency
         run: ./scripts/check-version-consistency.sh
 

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -30,9 +30,6 @@ annotations:
       url: https://github.com/themoah/klag/issues
     - name: documentation
       url: https://github.com/themoah/klag/blob/main/README.md
-  artifacthub.io/images: |
-    - name: klag
-      image: themoah/klag:0.2.9
   artifacthub.io/maintainers: |
     - name: themoah
       email: aviv@dozorets.com

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -3,11 +3,11 @@
 # pipeline never builds.
 #
 # release.yml builds `themoah/klag:<build.gradle.kts version>` on the
-# `klag-<chart version>` tag that chart-releaser cuts. So Chart.yaml `appVersion`
-# AND the `artifacthub.io/images` annotation tag MUST equal the gradle version.
-# When they drifted, a chart was published pointing at `themoah/klag:0.1.14`, an
-# image that was never pushed, and Artifact Hub's security scan failed forever on
-# that stale version. This check fails the build before such a chart is published.
+# `klag-<chart version>` tag that chart-releaser cuts. Chart.yaml `appVersion`
+# MUST equal the gradle version (the deployment template defaults image.tag to
+# appVersion). When they drifted, a chart was published pointing at a tag that
+# was never pushed, and Artifact Hub's security scan failed on that stale
+# version. This check fails the build before such a chart is published.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -15,28 +15,19 @@ cd "$repo_root"
 
 gradle_ver=$(grep -oE '^version = "[^"]+"' build.gradle.kts | sed -E 's/.*"([^"]+)".*/\1/')
 app_ver=$(grep -oE '^appVersion: "[^"]+"' charts/klag/Chart.yaml | sed -E 's/.*"([^"]+)".*/\1/')
-img_tag=$(grep -oE 'image: themoah/klag:[^[:space:]]+' charts/klag/Chart.yaml | sed -E 's/.*://')
 
 # Empty = grep matched nothing (file moved/reformatted). Without this the later
 # "$a" != "$b" checks pass on "" == "" and report a false OK.
-for v in gradle_ver app_ver img_tag; do
+for v in gradle_ver app_ver; do
   if [[ -z "${!v}" ]]; then
     echo "::error::Could not extract $v — build.gradle.kts / Chart.yaml format changed?"
     exit 1
   fi
 done
 
-fail=0
 if [[ "$app_ver" != "$gradle_ver" ]]; then
   echo "::error::Chart appVersion ($app_ver) != build.gradle.kts version ($gradle_ver)"
-  fail=1
-fi
-if [[ "$img_tag" != "$gradle_ver" ]]; then
-  echo "::error::artifacthub.io/images tag ($img_tag) != build.gradle.kts version ($gradle_ver)"
-  fail=1
-fi
-if [[ "$fail" -ne 0 ]]; then
   echo "release.yml builds themoah/klag:$gradle_ver; the chart must reference exactly that tag."
   exit 1
 fi
-echo "Version consistency OK: gradle=$gradle_ver appVersion=$app_ver image=$img_tag"
+echo "Version consistency OK: gradle=$gradle_ver appVersion=$app_ver"


### PR DESCRIPTION
## Summary
- Remove `artifacthub.io/images` from `charts/klag/Chart.yaml` so Artifact Hub no longer depends on a hand-maintained image tag (it dry-runs the chart instead).
- Narrow `check-version-consistency.sh` to `appVersion` vs gradle version only.
- Note: stopping the existing scan emails for chart `0.2.0`/`0.2.1` still requires dropping those versions from the `gh-pages` Helm index.

## Test plan
- [ ] `./scripts/check-version-consistency.sh` passes
- [ ] `helm lint charts/klag` passes
- [ ] After merge + chart release, Artifact Hub indexes the new chart without a manual images annotation
- [ ] (Separate) Remove chart versions `0.2.0` and `0.2.1` from `gh-pages` `index.yaml` to clear the current scan error emails


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Align Helm chart version metadata with the Gradle build version while removing Artifact Hub’s reliance on a hard-coded image tag.

Bug Fixes:
- Prevent publishing Helm charts whose appVersion drifts from the Gradle build version, avoiding broken Artifact Hub scans.

Enhancements:
- Simplify the version consistency check script to compare only appVersion and Gradle version and update related CI comments.
- Remove the Artifact Hub images annotation from the Helm chart so Artifact Hub infers images from chart rendering instead of a manually maintained tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release workflow guidance for detecting chart version drift that can affect Artifact Hub indexing.

* **Chores**
  * Simplified chart version validation to compare the application version with the build version.
  * Removed outdated container image metadata from the chart configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->