### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+Klag is a Kafka consumer lag exporter (Vert.x 4.5.22, Java 21). The authoritative
+reference for env vars, metrics, architecture, and build commands lives in `CLAUDE.md`
+and `.cursor/rules/project.mdc` — read those first.
+
+## Cursor Cloud specific instructions
+
+Environment is pre-provisioned by the update script: **JDK 21** (system `java`) and
+**Gradle 8.14.3** (system `gradle` at `/usr/local/bin/gradle`) are already installed.
+
+- **Use `gradle` directly, NOT `./gradlew`.** The Gradle wrapper JAR is not committed
+  (no `gradle/wrapper/` dir), so `./gradlew` fails with "Unable to access jarfile". This
+  contradicts `CLAUDE.md` which mentions `./gradlew` for local dev — on Cloud, always run
+  the bare `gradle` (same as CI). Standard tasks (`gradle compileJava|test|assemble|run`)
+  are documented in `CLAUDE.md`.
+- **The app boots without Kafka.** `/healthz` returns 200 and `/version` works even with no
+  broker; `/readyz` returns 503 until Kafka is reachable, then 200. Kafka is the only hard
+  runtime dependency, and it's only needed to produce real lag metrics.
+- **Running against a broker (dev):** start Kafka, then
+  `METRICS_REPORTER=prometheus KAFKA_BOOTSTRAP_SERVERS=localhost:9092 gradle run`.
+  Metrics are served at `http://localhost:8888/metrics` (`HTTP_PORT` default 8888). Lag
+  series only appear once a consumer group with committed offsets exists and a metrics
+  cycle has run (`METRICS_INTERVAL_MS`, default 60000 — lower it for faster feedback).
+  `METRICS_REPORTER` must be set (not `none`) for `/metrics` and `/mcp` snapshots to populate.
+- **No broker is bundled.** `docker` is not installed, so `docker-compose.yaml` and the
+  `scripts/e2e*.sh` / Helm / k3d flows need Docker/helm/kubectl installed first (optional,
+  not required for JVM dev). A quick local broker: download Apache Kafka and run it in
+  KRaft mode (`kafka-storage.sh format` then `kafka-server-start.sh config/kraft/server.properties`).
+- The `website/` dir (Astro docs site, Node ≥22.12) is independent of the exporter and not
+  needed to build/run/test Klag.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the Klag development environment for Cursor Cloud agents.

- Installs the toolchain in the VM snapshot: **JDK 21** (already present) + **Gradle 8.14.3** (pinned to the same version/checksum as the `Dockerfile`).
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing the non-obvious gotcha that `./gradlew` does **not** work (wrapper JAR is not committed) — use the bare `gradle` command like CI does.
- Registers a minimal, idempotent update script: `gradle dependencies --no-daemon`.

## Verification (real Kafka, KRaft single node)

Built and ran the exporter end-to-end against a local Kafka broker with a consumer group intentionally lagging by 800 messages:

- ✅ `gradle compileJava`, `gradle test`, `gradle assemble` (fat JAR `klag-0.2.9-fat.jar`)
- ✅ `gradle run` boots on `:8888`; `/healthz` 200, `/readyz` 200 (Kafka UP), `/version` OK
- ✅ `/metrics` exports `klag_consumer_lag_sum{consumer_group="demo-group",topic="demo-topic"} 800.0` — matching `kafka-consumer-groups.sh --describe`
- ✅ `/mcp` `get_consumer_group_lag` returns the full per-partition lag breakdown

[klag_e2e_evidence.log](https://cursor.com/agents/bc-7698d453-e2b7-4b3a-8d1e-e09ccf7cf7e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fklag_e2e_evidence.log)

No application code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7698d453-e2b7-4b3a-8d1e-e09ccf7cf7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7698d453-e2b7-4b3a-8d1e-e09ccf7cf7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Documentation:
- Add AGENTS.md documenting Cursor Cloud-specific setup, Gradle usage, and runtime behavior for Klag in the pre-provisioned dev environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cloud development guidance, including required Java and Gradle versions.
  * Documented local runtime health behavior, broker-based development, metrics setup, and optional container orchestration workflows.
  * Added requirements for independent website development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->