### PR TITLE
Chore/add deepwiki badge

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Something isn't working as expected.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, what you expected, and how to reproduce.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Klag version
+      description: Image tag, Helm appVersion, or `GET /version`.
+      placeholder: e.g. 0.2.10
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: How you run Klag (Docker / Helm / JAR), metrics reporter, Kafka version if relevant.
+      placeholder: Docker JVM, prometheus, Kafka 3.8 / Strimzi
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant logs or `/metrics` snippets. Redact secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://klag.dev
+    about: Configuration, deployment, metrics, and Kafka ACL guides.
+  - name: Migration from kafka-lag-exporter
+    url: https://klag.dev/migration
+    about: Metric/label/config mapping and dashboard tips.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Suggest a new metric, config option, integration, or docs improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Check [klag.dev](https://klag.dev) and [open issues](https://github.com/themoah/klag/issues)
+        in case it already exists or is planned.
+
+  - type: checkboxes
+    id: existing
+    attributes:
+      label: Existing issue?
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that Klag does not support today?
+      placeholder: e.g. I need to alert when commit staleness exceeds X only for groups matching …
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like Klag to do? Metric name/tags, env var, MCP tool, Helm knob, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds, other exporters, PromQL, or configs you tried.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Metrics / collection
+        - Configuration
+        - Helm chart
+        - Docker / native image
+        - MCP / AI agents
+        - Documentation / dashboard
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Examples, sketches, links to kafka-lag-exporter parity notes, etc.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License][license-badge]][license] [![Release][release-badge]][release] [![CI][ci-badge]][ci]
 
-[![Docker Pulls][docker-badge]][docker] [![Artifact Hub][artifacthub-badge]][artifacthub] [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/themoah/klag)
+[![Docker Pulls][docker-badge]][docker] [![Artifact Hub][artifacthub-badge]][artifacthub] [![Ask DeepWiki][deepwiki-badge]][deepwiki]
 
 [license]: https://github.com/themoah/klag/blob/main/LICENSE
 [license-badge]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
@@ -14,6 +14,8 @@
 [docker-badge]: https://img.shields.io/docker/pulls/themoah/klag?logo=docker
 [artifacthub]: https://artifacthub.io/packages/helm/klag/klag
 [artifacthub-badge]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/klag
+[deepwiki]: https://deepwiki.com/themoah/klag
+[deepwiki-badge]: https://deepwiki.com/badge.svg
 
 **Kafka Consumer Lag Exporter** — Know when your consumers fall behind, before it becomes a problem.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# Klag [![license-badge][]][license]
+# Klag
 
-[license]:             https://github.com/themoah/klag/blob/main/LICENSE
-[license-badge]:       https://img.shields.io/badge/License-Apache%202.0-blue.svg
+[![License][license-badge]][license] [![Release][release-badge]][release] [![CI][ci-badge]][ci]
+
+[![Docker Pulls][docker-badge]][docker] [![Artifact Hub][artifacthub-badge]][artifacthub] [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/themoah/klag)
+
+[license]: https://github.com/themoah/klag/blob/main/LICENSE
+[license-badge]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
+[release]: https://github.com/themoah/klag/releases/latest
+[release-badge]: https://img.shields.io/github/v/release/themoah/klag?logo=github
+[ci]: https://github.com/themoah/klag/actions/workflows/build-and-push.yml
+[ci-badge]: https://github.com/themoah/klag/actions/workflows/build-and-push.yml/badge.svg
+[docker]: https://hub.docker.com/r/themoah/klag
+[docker-badge]: https://img.shields.io/docker/pulls/themoah/klag?logo=docker
+[artifacthub]: https://artifacthub.io/packages/helm/klag/klag
+[artifacthub-badge]: https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/klag
 
 **Kafka Consumer Lag Exporter** — Know when your consumers fall behind, before it becomes a problem.
 


### PR DESCRIPTION
## Summary by Sourcery

Update project README badges and add GitHub issue templates for feature requests and bug reports.

CI:
- Introduce structured GitHub issue templates for feature requests and bug reports, plus a config file with documentation and migration contact links.

Documentation:
- Expand README with license, release, CI, Docker, Artifact Hub, and DeepWiki badges for better project and support visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured templates for submitting bug reports and feature requests, with required prompts and optional fields (including environment and logs for bugs).
  * Enabled blank issue submissions.
  * Added built-in project contact links for documentation and migration guidance.

* **Documentation**
  * Refreshed the README top section with additional status/download badges (e.g., releases, CI, Docker pulls, Artifact Hub, and project resources).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->