### PR TITLE
improving stale group cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.11"
+version = "0.2.12"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -3,7 +3,7 @@ name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
 version: 0.3.7
-appVersion: "0.2.11"
+appVersion: "0.2.12"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -235,6 +235,7 @@ public class MetricsCollector {
     log.debug("Collecting lag metrics");
     collectionInFlight = true;
     cycleTopicOffsets.clear();
+    long cycleStartNanos = System.nanoTime();
 
     return kafkaClient.listConsumerGroups()
       .compose(groups -> {
@@ -261,7 +262,11 @@ public class MetricsCollector {
         return collectAllGroupsParallel(filteredGroups);
       })
       .onFailure(err -> log.error("Failed to collect lag metrics", err))
-      .onComplete(ar -> collectionInFlight = false);
+      .onComplete(ar -> {
+        collectionInFlight = false;
+        long cycleMs = (System.nanoTime() - cycleStartNanos) / 1_000_000L;
+        log.info("Collection cycle finished in {}ms (success={})", cycleMs, ar.succeeded());
+      });
   }
 
   /**

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
@@ -38,9 +38,16 @@ public class MicrometerReporter {
 
   private final MeterRegistry registry;
   private final boolean memberLabelsEnabled;
-  private final Map<String, AtomicLong> gaugeValues = new ConcurrentHashMap<>();
+  /** Gauge value + registered meter, keyed by {@code name + tags.toString()}. */
+  private final Map<String, HeldGauge> gauges = new ConcurrentHashMap<>();
   private final Set<String> markedForDeletion = ConcurrentHashMap.newKeySet();
   private final ConsumerGroupStateTracker stateTracker = new ConsumerGroupStateTracker();
+
+  /**
+   * Holds the mutable gauge value together with the Micrometer {@link Meter} so stale cleanup
+   * can remove from the registry in O(1) without scanning {@code registry.getMeters()}.
+   */
+  private record HeldGauge(AtomicLong value, Meter meter) {}
 
   public MicrometerReporter(MeterRegistry registry) {
     this(registry, true);
@@ -431,16 +438,21 @@ public class MicrometerReporter {
     return Future.succeededFuture();
   }
 
+  /**
+   * Registers or updates a gauge. The map key is {@code name + tags.toString()} — use
+   * {@link Tags#toString()} (no spaces after commas), not {@code Meter.Id#getTags()} list
+   * formatting, so keys stay stable across report and cleanup.
+   */
   private String recordGauge(String name, Tags tags, long value) {
     String key = name + tags.toString();
-    AtomicLong atomicValue = gaugeValues.computeIfAbsent(key, k -> {
+    HeldGauge held = gauges.computeIfAbsent(key, k -> {
       AtomicLong newValue = new AtomicLong(value);
-      Gauge.builder(name, newValue, AtomicLong::get)
+      Meter meter = Gauge.builder(name, newValue, AtomicLong::get)
         .tags(tags)
         .register(registry);
-      return newValue;
+      return new HeldGauge(newValue, meter);
     });
-    atomicValue.set(value);
+    held.value().set(value);
     return key;
   }
 
@@ -452,19 +464,21 @@ public class MicrometerReporter {
    * @param activeKeys set of gauge keys that were updated in the current cycle
    */
   public void cleanupStaleGauges(Set<String> activeKeys) {
-    Set<String> currentKeys = gaugeValues.keySet();
+    Set<String> currentKeys = gauges.keySet();
 
     // Phase 2: Delete gauges marked for deletion that are still missing
     Set<String> toDelete = new HashSet<>(markedForDeletion);
     toDelete.removeAll(activeKeys);
 
+    long deleteStartNanos = System.nanoTime();
     for (String key : toDelete) {
       removeGauge(key);
       markedForDeletion.remove(key);
     }
 
     if (!toDelete.isEmpty()) {
-      log.info("Cleaned up {} stale gauges", toDelete.size());
+      long deleteMs = (System.nanoTime() - deleteStartNanos) / 1_000_000L;
+      log.info("Cleaned up {} stale gauges in {}ms", toDelete.size(), deleteMs);
     }
 
     // Phase 1: Mark currently missing gauges for deletion
@@ -484,21 +498,10 @@ public class MicrometerReporter {
   }
 
   private void removeGauge(String key) {
-    AtomicLong value = gaugeValues.remove(key);
-    if (value != null) {
-      registry.getMeters().stream()
-        .filter(meter -> buildMeterKey(meter).equals(key))
-        .findFirst()
-        .ifPresent(registry::remove);
+    HeldGauge held = gauges.remove(key);
+    if (held != null) {
+      registry.remove(held.meter());
       log.debug("Removed stale gauge: {}", key);
     }
-  }
-
-  // Must match recordGauge's key exactly. Meter.Id#getTags() returns a List<Tag> whose
-  // toString() puts a space after each comma ("[tag(a=b), tag(c=d)]"), whereas Tags#toString()
-  // does not ("[tag(a=b),tag(c=d)]"). Wrapping in Tags.of() reproduces the recordGauge format,
-  // otherwise stale meters are dropped from gaugeValues but never removed from the registry.
-  private String buildMeterKey(Meter meter) {
-    return meter.getId().getName() + Tags.of(meter.getId().getTags()).toString();
   }
 }

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerReporter.java
@@ -473,8 +473,8 @@ public class MicrometerReporter {
     long deleteStartNanos = System.nanoTime();
     for (String key : toDelete) {
       removeGauge(key);
-      markedForDeletion.remove(key);
     }
+    markedForDeletion.removeAll(toDelete);
 
     if (!toDelete.isEmpty()) {
       long deleteMs = (System.nanoTime() - deleteStartNanos) / 1_000_000L;

--- a/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterCleanupTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MicrometerReporterCleanupTest.java
@@ -1,0 +1,58 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.themoah.klag.model.UnderReplicatedPartition;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies two-phase stale-gauge cleanup removes large batches from the registry in O(1)
+ * per delete (HeldGauge retains the Meter reference) — regression for issue #68.
+ */
+class MicrometerReporterCleanupTest {
+
+  private static final int BATCH_SIZE = 2000;
+  private static final long DELETE_BUDGET_MS = 2000L;
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void largeBatchCleanupRemovesAllMetersWithinBudget() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerReporter reporter = new MicrometerReporter(registry);
+
+    List<UnderReplicatedPartition> partitions = new ArrayList<>(BATCH_SIZE);
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      partitions.add(new UnderReplicatedPartition("topic-" + (i / 10), i % 10, 3, 2));
+    }
+
+    Set<String> cycle1 = new HashSet<>();
+    reporter.reportUnderReplicatedPartitions(partitions, cycle1);
+    reporter.cleanupStaleGauges(cycle1);
+
+    assertEquals(BATCH_SIZE, registry.find("klag.partition.under_replicated").gauges().size(),
+      "all gauges registered after first cycle");
+
+    // Two empty cycles: mark, then delete (same contract as other cleanup tests).
+    reporter.cleanupStaleGauges(Set.of());
+
+    long deleteStartNanos = System.nanoTime();
+    reporter.cleanupStaleGauges(Set.of());
+    long deleteMs = (System.nanoTime() - deleteStartNanos) / 1_000_000L;
+
+    assertNull(registry.find("klag.partition.under_replicated").gauge(),
+      "all under-replicated gauges removed after two-phase cleanup");
+    assertEquals(0, registry.find("klag.partition.under_replicated").gauges().size());
+    assertTrue(deleteMs < DELETE_BUDGET_MS,
+      "deleting " + BATCH_SIZE + " gauges must finish under " + DELETE_BUDGET_MS
+        + "ms (O(1) remove); took " + deleteMs + "ms");
+  }
+}


### PR DESCRIPTION
Fixing https://github.com/themoah/klag/issues/68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timing and success-status logging for metric collection cycles.
  * Improved stale metric cleanup for faster removal and clearer timing information.

* **Bug Fixes**
  * Ensured stale gauges are reliably removed during cleanup.

* **Tests**
  * Added regression coverage confirming large numbers of stale gauges are removed within the expected time limit.

* **Chores**
  * Updated the project and Helm chart versions to 0.2.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->