### PR TITLE
fix: harden metrics collection edge cases

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Klag
 
-Kafka consumer lag exporter (Vert.x 4.5.22, Java 21). Monitors lag, velocity, hot partitions, time-based lag, commit freshness, ISR, and group state. Exports to Prometheus, Datadog, or OTLP.
+Kafka consumer lag exporter (Vert.x 4.5.30, Java 21). Monitors lag, velocity, hot partitions, time-based lag, commit freshness, ISR, and group state. Exports to Prometheus, Datadog, or OTLP.
 
 ## Build
 

--- a/.gitignore
+++ b/.gitignore
@@ -162,9 +162,8 @@ buildNumber.properties
 # Ignore Gradle GUI config
 gradle-app.setting
 
-# Gradle wrapper binaries are NOT committed (CI runs gradle directly); `./gradlew`
-# regenerates gradle/wrapper/ locally on first run.
-gradle/wrapper/
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
 
 # Cache of project
 .gradletasknamecache

--- a/.gitignore
+++ b/.gitignore
@@ -162,8 +162,9 @@ buildNumber.properties
 # Ignore Gradle GUI config
 gradle-app.setting
 
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+# Gradle wrapper binaries are NOT committed (CI runs gradle directly); `./gradlew`
+# regenerates gradle/wrapper/ locally on first run.
+gradle/wrapper/
 
 # Cache of project
 .gradletasknamecache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Klag is a Kafka Lag Exporter built with Vert.x 4.5.22. Monitors consumer lag and group states with Prometheus/Datadog/OTLP metrics.
+Klag is a Kafka Lag Exporter built with Vert.x 4.5.30. Monitors consumer lag and group states with Prometheus/Datadog/OTLP metrics.
 
 ## Build Commands
 
@@ -59,6 +59,14 @@ src/main/java/io/github/themoah/klag/
 └── model/                     # Records: ConsumerGroupLag, ConsumerGroupState, PartitionOffsets, LagVelocity, etc.
 ```
 
+**Collection cycle (keep this shape).** Each cycle runs in two phases: committed offsets for
+every group (in waves of `KAFKA_MAX_CONCURRENT_GROUPS`), then **one** batched
+`getLogEndOffsets(Set<String>)` for the union of their topics — one `describeTopics` plus
+three `listOffsets` for the whole set, not per topic. Lag assembly is then pure computation.
+Admin request volume must stay independent of topic count; reintroducing a per-topic fetch
+regresses it to 4 requests × every topic × every cycle.
+`MetricsCollectorBatchingTest` pins this.
+
 ## HTTP Endpoints
 
 | Endpoint | Purpose |
@@ -75,7 +83,7 @@ src/main/java/io/github/themoah/klag/
 
 Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAME` → JVM property `-DNAME` → dotted `-Dname.dotted` (e.g. `HTTP_PORT` → `-Dhttp.port`). This lets jar/native users configure via `-D`; env keeps precedence. See `config/Env.java#resolve`.
 
-**Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1), `KAFKA_CHUNK_DELAY_MS` (0). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
+**Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1 — chunking is *off*; only values >1 enable it), `KAFKA_CHUNK_DELAY_MS` (0), `KAFKA_MAX_CONCURRENT_GROUPS` (50 — caps how many consumer-group offset requests are in flight at once; a concurrency bound, not a throttle, so it applies regardless of chunking). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
 
 **Metrics:** `METRICS_REPORTER` (none/prometheus/datadog/otlp), `METRICS_INTERVAL_MS` (60000), `METRICS_GROUP_FILTER` (comma-separated glob patterns, default `*`), `METRICS_GROUP_EXCLUDE` (comma-separated glob patterns, default empty), `METRICS_JVM_ENABLED` (false), `CONSUMER_MEMBER_LABELS_ENABLED` (true — tag per-partition `klag.consumer.lag`, `klag.consumer.lag.ms`, and `klag.consumer.committed_offset` with `member_host`/`consumer_id`/`client_id` for the owning consumer instance; kafka-lag-exporter parity. Empty-string values for unowned partitions; set `false` to drop the labels and cut cardinality), `LAG_TREND_DEADBAND_MSG_PER_SEC` (1.0 — STABLE band for the MCP basic lag-trend classifier; |velocity| within the band is STABLE). A group is monitored iff it matches any include segment AND no exclude segment.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@ src/main/java/io/github/themoah/klag/
 **Collection cycle (keep this shape).** Each cycle runs in two phases: committed offsets for
 every group (in waves of `KAFKA_MAX_CONCURRENT_GROUPS`), then **one** batched
 `getLogEndOffsets(Set<String>)` for the union of their topics — one `describeTopics` plus
-three `listOffsets` for the whole set, not per topic. Lag assembly is then pure computation.
+three `listOffsets` for the whole set, not per topic (with `KAFKA_CHUNK_COUNT > 1` the union
+is split into that many batches, so it is one such batched call *per chunk*, still not per
+topic). Lag assembly is then pure computation.
 Admin request volume must stay independent of topic count; reintroducing a per-topic fetch
 regresses it to 4 requests × every topic × every cycle.
 `MetricsCollectorBatchingTest` pins this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,21 @@ Admin request volume must stay independent of topic count; reintroducing a per-t
 regresses it to 4 requests × every topic × every cycle.
 `MetricsCollectorBatchingTest` pins this.
 
+**Deleted topics are filtered before describeTopics.** The Vert.x wrapper resolves
+`describeTopics` via `allTopicNames()`, so one unknown topic fails the whole batch — and
+committed offsets outlive a deleted topic until `offsets.retention.minutes` (7d), which would
+keep every cycle partial and stale-gauge cleanup frozen that long. The union is intersected
+with one cached `listTopics()` per cycle; absent topics are treated as deleted (series retired
+in 1–2 cycles). Cost: asymmetric ACLs (offsets readable, topic not) look like deletion.
+A failed `listTopics` must propagate, never fall through unfiltered.
+
+**Partial cycles skip cleanup but still publish the MCP snapshot.** A permanently failing
+group (ACL gap, wedged coordinator) freezes stale-gauge cleanup indefinitely — deliberate
+(cleaning against an incomplete key set deletes live series), documented in troubleshooting,
+fixed by ACL or `METRICS_GROUP_EXCLUDE`. The snapshot is exempt so agents don't read
+hours-old data while `/metrics` stays current; an *empty* snapshot is not published, since
+wiping the agent view is worse than a stale one.
+
 ## HTTP Endpoints
 
 | Endpoint | Purpose |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ and [charts/klag/README.md](charts/klag/README.md).
 | `klag.consumer.lag.ms` | Lag in ms from Kafka log timestamps                            |
 | `klag.consumer.lag.time_to_close_seconds` | Estimated seconds until lag reaches zero    |
 | `klag.consumer.lag.retention_percent` | Lag as % of available messages (data loss alerting) |
-| `klag.consumer.group.state` | Group health: Stable, Rebalancing, Dead, Empty           |
+| `klag.consumer.group.state` | Group health: stable, preparing/completing_rebalance (assigning/reconciling on KIP-848 groups), dead, empty |
 | `klag.hot_partition[.lag]` | Partitions with statistically abnormal throughput         |
 | `klag.partition.under_replicated` | Partitions with fewer in-sync replicas than configured (ISR gap) |
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ End-to-end tests (k3d + real Kafka, Strimzi matrix) live in `scripts/`. See
 
 ---
 
-[![vert.x](https://img.shields.io/badge/vert.x-4.5.22-purple.svg)](https://vertx.io)
+[![vert.x](https://img.shields.io/badge/vert.x-4.5.30-purple.svg)](https://vertx.io)
 
 Some parts of the code were written with Claude
 <img src="https://raw.githubusercontent.com/lobehub/lobe-icons/refs/heads/master/packages/static-png/dark/claude-color.png" width="56" height="56" alt="Claude">

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ See [CLAUDE.md](CLAUDE.md) for the complete configuration reference.
 
 ## Broker Compatibility
 
-Klag works with Apache Kafka **2.x and 3.x** brokers.
+Klag works with Apache Kafka **2.1 through 4.x** brokers. The lower bound comes from
+`kafka-clients` 4.x, which dropped support for brokers older than 2.1. CI e2e-tests
+against 4.1 and 4.2 (`scripts/e2e-strimzi-matrix.sh`); older brokers are covered by unit
+tests of the fallback paths, since Strimzi no longer ships images that old.
 
 ### Running against Kafka 2.x
 
@@ -160,7 +163,7 @@ further occurrences at DEBUG. Cause: ...
 
 Klag asks the broker for partition end-offsets using `OffsetSpec.MAX_TIMESTAMP`, an API added in Kafka 3.0 ([KIP-734](https://cwiki.apache.org/confluence/display/KAFKA/KIP-734%3A+Improve+AdminClient.listOffsets+to+return+timestamp+and+offset+for+the+record+with+the+largest+timestamp)). 2.x brokers don't support it and respond with `UnsupportedVersionException`. Klag catches that and falls back to `OffsetSpec.LATEST`, which every Kafka version supports. The fallback returns the same partition end-offset that drives every lag metric, so accuracy is preserved.
 
-**Why the fallback is necessary.** Without it, klag refuses to start on a 2.x cluster. The first metrics scrape runs synchronously during klag's startup, and a failure there propagates back up to the process launcher, which exits with code 1 — CrashLoopBackOff under Kubernetes. One consumer group on a 2.x cluster was enough to brick startup.
+**Why the fallback is necessary.** Without it, every collection cycle fails against a 2.x broker and klag exports no lag metrics at all — one consumer group on a 2.x cluster was enough. It used to be worse: the first scrape ran synchronously during startup and its failure propagated to the process launcher, which exited with code 1 (CrashLoopBackOff under Kubernetes). The first cycle is now recovered so an unreachable or incompatible broker degrades instead of bricking startup, but that only buys a running process — the fallback is what makes the metrics correct.
 
 **Note for future contributors.** On 2.x brokers, both `logEndTimestamp` and `maxTimestampOffset` fall back to the LATEST offset's timestamp/offset, so time-based lag interpolation degrades gracefully (the anchor becomes the broker-side append time of the last record rather than the highest-timestamp record).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.13"
+version = "0.2.14"
 
 repositories {
   mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.12"
+version = "0.2.13"
 
 repositories {
   mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.14"
+version = "0.2.13"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.7
-appVersion: "0.2.12"
+version: 0.3.8
+appVersion: "0.2.13"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -48,3 +48,9 @@ annotations:
       description: Per-consumer-instance member labels (member_host, consumer_id, client_id) on consumer-owned lag metrics for kafka-lag-exporter parity; opt out with CONSUMER_MEMBER_LABELS_ENABLED=false
     - kind: fixed
       description: Stale gauges are now actually removed from the registry (key-format mismatch left old series lingering on /metrics)
+    - kind: fixed
+      description: Klag no longer exits (and crash-loops) when Kafka is unreachable during the first metrics collection; the first cycle now degrades like the health monitor
+    - kind: fixed
+      description: Topic names containing ':' no longer break every collection cycle (hot-partition throughput detection parsed the topic out of its internal key)
+    - kind: fixed
+      description: A cycle that observes no consumer groups now runs the full cycle-end cleanup and refreshes the MCP snapshot instead of leaving stale tracker history and a frozen snapshot

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.9
-appVersion: "0.2.14"
+version: 0.3.8
+appVersion: "0.2.13"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -34,6 +34,12 @@ annotations:
     - name: themoah
       email: aviv@dozorets.com
   artifacthub.io/changes: |
+    - kind: fixed
+      description: A topic deleted while a group still has committed offsets for it no longer keeps every cycle partial (which froze stale-series cleanup for up to offsets.retention.minutes); such topics are filtered out and their series retired
+    - kind: fixed
+      description: The MCP snapshot now refreshes on a partial cycle instead of freezing at the last complete one, so one failing consumer group no longer leaves AI agents reading stale data while /metrics stays current
+    - kind: added
+      description: KIP-848 consumer-protocol group states (assigning, reconciling) are reported as their own state tag values instead of collapsing to unknown; rebalance alerts should match all four rebalance states
     - kind: changed
       description: Batch topic offset lookups into one describeTopics + three listOffsets per cycle (per chunk when KAFKA_CHUNK_COUNT > 1) instead of four admin requests per topic, cutting broker load and cycle time on clusters with many topics
     - kind: added

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.8
-appVersion: "0.2.13"
+version: 0.3.9
+appVersion: "0.2.14"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -34,6 +34,12 @@ annotations:
     - name: themoah
       email: aviv@dozorets.com
   artifacthub.io/changes: |
+    - kind: changed
+      description: Batch topic offset lookups into one describeTopics + three listOffsets per cycle instead of four admin requests per topic, cutting broker load and cycle time on clusters with many topics
+    - kind: added
+      description: KAFKA_MAX_CONCURRENT_GROUPS (default 50) bounds how many consumer-group offset requests are in flight at once
+    - kind: fixed
+      description: Leaderless (offline) partitions no longer throw while reading topic metadata, which previously dropped the whole topic from a collection cycle
     - kind: changed
       description: Enable Java 21 virtual threads by default (app.useVirtualThreads=true); set false for event-loop deployment
     - kind: fixed

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -35,7 +35,7 @@ annotations:
       email: aviv@dozorets.com
   artifacthub.io/changes: |
     - kind: changed
-      description: Batch topic offset lookups into one describeTopics + three listOffsets per cycle instead of four admin requests per topic, cutting broker load and cycle time on clusters with many topics
+      description: Batch topic offset lookups into one describeTopics + three listOffsets per cycle (per chunk when KAFKA_CHUNK_COUNT > 1) instead of four admin requests per topic, cutting broker load and cycle time on clusters with many topics
     - kind: added
       description: KAFKA_MAX_CONCURRENT_GROUPS (default 50) bounds how many consumer-group offset requests are in flight at once
     - kind: fixed

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -162,7 +162,7 @@ Set `KLAG_CONFIG_FILE` to the path of an external `application.properties` (typi
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `app.healthCheckIntervalMs` | Kafka health check interval (ms) | `30000` |
-| `app.useVirtualThreads` | Enable Java 21 virtual threads | `false` |
+| `app.useVirtualThreads` | Enable Java 21 virtual threads | `true` |
 
 ### MCP Configuration (AI agent endpoint)
 

--- a/charts/klag/values.yaml
+++ b/charts/klag/values.yaml
@@ -210,7 +210,8 @@ extraVolumeMounts: []
 
 # Additional environment variables for the klag container (verbatim EnvVar entries).
 # Escape hatch for settings without first-class values: HOT_PARTITION_*, TIME_LAG_*,
-# KAFKA_CHUNK_*, LAG_TREND_DEADBAND_MSG_PER_SEC, KLAG_CONFIG_FILE, LOG_LEVEL_KAFKA_CLIENT, ...
+# KAFKA_CHUNK_*, KAFKA_MAX_CONCURRENT_GROUPS, LAG_TREND_DEADBAND_MSG_PER_SEC,
+# KLAG_CONFIG_FILE, LOG_LEVEL_KAFKA_CLIENT, ...
 # Example:
 #   - name: KAFKA_CHUNK_COUNT
 #     value: "4"

--- a/dashboard/demo-dashboard.json
+++ b/dashboard/demo-dashboard.json
@@ -711,9 +711,19 @@
                               "index": 4,
                               "text": "Completing Rebalance"
                             },
+                            "assigning": {
+                              "color": "yellow",
+                              "index": 5,
+                              "text": "Assigning"
+                            },
+                            "reconciling": {
+                              "color": "yellow",
+                              "index": 6,
+                              "text": "Reconciling"
+                            },
                             "unknown": {
                               "color": "orange",
-                              "index": 5,
+                              "index": 7,
                               "text": "Unknown"
                             }
                           },

--- a/dashboard/klag-grafana-com.json
+++ b/dashboard/klag-grafana-com.json
@@ -618,9 +618,19 @@
                         "index": 4,
                         "text": "Completing Rebalance"
                       },
+                      "assigning": {
+                        "color": "yellow",
+                        "index": 5,
+                        "text": "Assigning"
+                      },
+                      "reconciling": {
+                        "color": "yellow",
+                        "index": 6,
+                        "text": "Reconciling"
+                      },
                       "unknown": {
                         "color": "orange",
-                        "index": 5,
+                        "index": 7,
                         "text": "Unknown"
                       }
                     },

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientService.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientService.java
@@ -5,9 +5,11 @@ import io.github.themoah.klag.model.ConsumerGroupState;
 import io.github.themoah.klag.model.PartitionInfo;
 import io.github.themoah.klag.model.PartitionOffsets;
 import io.vertx.core.Future;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Service interface for Kafka administrative operations.
@@ -37,6 +39,36 @@ public interface KafkaClientService {
    * @return Future containing list of partition offsets
    */
   Future<List<PartitionOffsets>> getLogEndOffsets(String topic);
+
+  /**
+   * Gets the log end offsets for all partitions of every given topic.
+   *
+   * <p>The real client overrides this with a single batched round-trip (one describeTopics
+   * plus three listOffsets for the whole set), which is what keeps admin request volume
+   * independent of topic count. This default fans out per topic so that alternative
+   * implementations — notably test fakes — stay correct without reimplementing anything.
+   *
+   * @param topics the topic names
+   * @return Future containing partition offsets grouped by topic; topics with no metadata
+   *     are absent from the map
+   */
+  default Future<Map<String, List<PartitionOffsets>>> getLogEndOffsets(Set<String> topics) {
+    if (topics == null || topics.isEmpty()) {
+      return Future.succeededFuture(Map.of());
+    }
+    List<String> ordered = List.copyOf(topics);
+    List<Future<List<PartitionOffsets>>> futures = ordered.stream()
+      .map(this::getLogEndOffsets)
+      .collect(Collectors.toList());
+
+    return Future.all(futures).map(composite -> {
+      Map<String, List<PartitionOffsets>> byTopic = new HashMap<>();
+      for (int i = 0; i < composite.size(); i++) {
+        byTopic.put(ordered.get(i), composite.resultAt(i));
+      }
+      return byTopic;
+    });
+  }
 
   /**
    * Gets the committed offsets for a consumer group.

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
@@ -103,9 +103,11 @@ public class KafkaClientServiceImpl implements KafkaClientService {
   /**
    * Describes every given topic in a single {@code describeTopics} round-trip.
    *
-   * <p>Topics absent from the response (deleted mid-cycle, not authorized) are simply missing
-   * from the returned map rather than failing the batch — one bad topic must not blind the
-   * whole collection cycle.
+   * <p>Note the Vert.x wrapper resolves this through {@code DescribeTopicsResult.allTopicNames()},
+   * so an unknown or unauthorized topic fails the whole batch before this mapping runs — callers
+   * must filter deleted topics out beforehand (MetricsCollector does, against listTopics). The
+   * null-description skip below only covers a broker returning a short map for a topic it did
+   * accept; it is deliberately tolerant so one odd topic cannot blind the whole cycle.
    */
   private Future<Map<String, List<PartitionInfo>>> describePartitions(Set<String> topics) {
     log.debug("Describing partitions for {} topics", topics.size());
@@ -159,7 +161,11 @@ public class KafkaClientServiceImpl implements KafkaClientService {
     return describePartitions(topics)
       .compose(partitionsByTopic -> {
         if (partitionsByTopic.isEmpty()) {
-          return Future.succeededFuture(Map.<String, List<PartitionOffsets>>of());
+          // Topics were requested and none came back with metadata: that is blindness, not
+          // "no topics". Succeeding empty here would make the cycle look complete and let
+          // stale-gauge cleanup delete every series in the cluster.
+          return Future.<Map<String, List<PartitionOffsets>>>failedFuture(new IllegalStateException(
+            "No topic metadata returned for any of the " + topics.size() + " requested topics"));
         }
 
         // Use MAX_TIMESTAMP to get the offset with highest timestamp (Kafka 3.0+)

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
@@ -82,28 +82,51 @@ public class KafkaClientServiceImpl implements KafkaClientService {
   public Future<Set<String>> listTopics() {
     log.debug("Listing all topics");
     return adminClient.listTopics()
-      .onSuccess(topics -> log.info("Listed {} topics", topics.size()))
+      .onSuccess(topics -> log.debug("Listed {} topics", topics.size()))
       .onFailure(err -> log.error("Failed to list topics", err));
   }
 
   @Override
   public Future<List<PartitionInfo>> listPartitions(String topic) {
     Objects.requireNonNull(topic, "topic cannot be null");
-    log.debug("Listing partitions for topic: {}", topic);
 
-    return adminClient.describeTopics(Collections.singletonList(topic))
-      .map(descriptions -> {
-        TopicDescription description = descriptions.get(topic);
-        if (description == null) {
+    return describePartitions(Set.of(topic))
+      .map(byTopic -> {
+        List<PartitionInfo> partitions = byTopic.get(topic);
+        if (partitions == null) {
           throw new IllegalArgumentException("Topic not found: " + topic);
         }
-        List<PartitionInfo> partitions = description.getPartitions().stream()
-          .map(partition -> toPartitionInfo(topic, partition))
-          .collect(Collectors.toList());
-        log.info("Topic {} has {} partitions", topic, partitions.size());
         return partitions;
+      });
+  }
+
+  /**
+   * Describes every given topic in a single {@code describeTopics} round-trip.
+   *
+   * <p>Topics absent from the response (deleted mid-cycle, not authorized) are simply missing
+   * from the returned map rather than failing the batch — one bad topic must not blind the
+   * whole collection cycle.
+   */
+  private Future<Map<String, List<PartitionInfo>>> describePartitions(Set<String> topics) {
+    log.debug("Describing partitions for {} topics", topics.size());
+
+    return adminClient.describeTopics(new ArrayList<>(topics))
+      .map(descriptions -> {
+        Map<String, List<PartitionInfo>> byTopic = new HashMap<>();
+        for (String topic : topics) {
+          TopicDescription description = descriptions.get(topic);
+          if (description == null || description.getPartitions() == null) {
+            log.warn("No topic metadata returned for {}; skipping it this cycle", topic);
+            continue;
+          }
+          byTopic.put(topic, description.getPartitions().stream()
+            .map(partition -> toPartitionInfo(topic, partition))
+            .collect(Collectors.toList()));
+        }
+        log.debug("Described {} of {} requested topics", byTopic.size(), topics.size());
+        return byTopic;
       })
-      .onFailure(err -> log.error("Failed to list partitions for topic: {}", topic, err));
+      .onFailure(err -> log.error("Failed to describe {} topics", topics.size(), err));
   }
 
   // Kafka 3.0+ MAX_TIMESTAMP spec value (not exposed by Vert.x wrapper)
@@ -113,10 +136,32 @@ public class KafkaClientServiceImpl implements KafkaClientService {
   @Override
   public Future<List<PartitionOffsets>> getLogEndOffsets(String topic) {
     Objects.requireNonNull(topic, "topic cannot be null");
-    log.debug("Getting log end offsets for topic: {}", topic);
+    return getLogEndOffsets(Set.of(topic))
+      .map(byTopic -> byTopic.getOrDefault(topic, List.of()));
+  }
 
-    return listPartitions(topic)
-      .compose(partitions -> {
+  /**
+   * Batched offset fetch: one {@code describeTopics} plus exactly three {@code listOffsets}
+   * calls for the entire topic set, regardless of how many topics it contains.
+   *
+   * <p>The Kafka AdminClient already splits a multi-topic {@code listOffsets} into one request
+   * per leader broker, so batching here is what keeps admin request volume proportional to
+   * cluster size rather than to (topic count x 4).
+   */
+  @Override
+  public Future<Map<String, List<PartitionOffsets>>> getLogEndOffsets(Set<String> topics) {
+    Objects.requireNonNull(topics, "topics cannot be null");
+    if (topics.isEmpty()) {
+      return Future.succeededFuture(Map.of());
+    }
+    log.debug("Getting log end offsets for {} topics", topics.size());
+
+    return describePartitions(topics)
+      .compose(partitionsByTopic -> {
+        if (partitionsByTopic.isEmpty()) {
+          return Future.succeededFuture(Map.<String, List<PartitionOffsets>>of());
+        }
+
         // Use MAX_TIMESTAMP to get the offset with highest timestamp (Kafka 3.0+)
         // Use TIMESTAMP(0) to get earliest offset with its timestamp
         // Use LATEST as fallback for offset if MAX_TIMESTAMP fails
@@ -124,14 +169,16 @@ public class KafkaClientServiceImpl implements KafkaClientService {
         Map<TopicPartition, OffsetSpec> earliestTimestampRequest = new HashMap<>();
         Map<TopicPartition, OffsetSpec> latestOffsetRequest = new HashMap<>();
 
-        for (PartitionInfo partition : partitions) {
-          TopicPartition tp = new TopicPartition(topic, partition.partition());
-          maxTimestampRequest.put(tp, new OffsetSpec(MAX_TIMESTAMP_SPEC));
-          earliestTimestampRequest.put(tp, OffsetSpec.TIMESTAMP(0));
-          latestOffsetRequest.put(tp, OffsetSpec.LATEST);
-        }
+        partitionsByTopic.forEach((topic, partitions) -> {
+          for (PartitionInfo partition : partitions) {
+            TopicPartition tp = new TopicPartition(topic, partition.partition());
+            maxTimestampRequest.put(tp, new OffsetSpec(MAX_TIMESTAMP_SPEC));
+            earliestTimestampRequest.put(tp, OffsetSpec.TIMESTAMP(0));
+            latestOffsetRequest.put(tp, OffsetSpec.LATEST);
+          }
+        });
 
-        // Three queries:
+        // Three queries, each spanning every partition of every requested topic:
         // 1. MAX_TIMESTAMP - returns offset with highest timestamp (Kafka 3.0+)
         // 2. TIMESTAMP(0) - returns earliest offset with its timestamp
         // 3. LATEST - fallback for actual latest offset
@@ -162,86 +209,99 @@ public class KafkaClientServiceImpl implements KafkaClientService {
                   + "falling back to LATEST for logEndTimestamp. Logged once per process; "
                   + "further occurrences at DEBUG. Cause: {}", composite.cause(0).toString());
             } else {
-              log.debug("MAX_TIMESTAMP listOffsets failed for topic {}; using LATEST fallback", topic);
+              log.debug("MAX_TIMESTAMP listOffsets failed; using LATEST fallback");
             }
             maxTimestampOffsets = Collections.emptyMap();
           } else {
             maxTimestampOffsets = composite.resultAt(0);
           }
-          Map<TopicPartition, ListOffsetsResultInfo> earliestTimestampOffsets = composite.resultAt(1);
-          Map<TopicPartition, ListOffsetsResultInfo> latestOffsets = composite.resultAt(2);
 
-          List<PartitionOffsets> result = new ArrayList<>();
-          boolean loggedSampleTimestamp = false;
-
-          for (PartitionInfo partition : partitions) {
-            TopicPartition tp = new TopicPartition(topic, partition.partition());
-
-            ListOffsetsResultInfo earliestResult = earliestTimestampOffsets.get(tp);
-            ListOffsetsResultInfo maxTimestampResult = maxTimestampOffsets.get(tp);
-            ListOffsetsResultInfo latestOffsetResult = latestOffsets.get(tp);
-
-            // The partition list comes from a separate describeTopics call; a partition can
-            // be missing from a listOffsets response (leaderless partition, partition added
-            // mid-call, per-partition broker error). Skip it instead of NPEing the whole topic.
-            if (earliestResult == null || latestOffsetResult == null) {
-              log.warn("Missing listOffsets result for {}-{} (earliest={}, latest={}); skipping partition",
-                topic, partition.partition(), earliestResult != null, latestOffsetResult != null);
-              continue;
-            }
-
-            // Get earliest offset and timestamp from TIMESTAMP(0)
-            long logStartOffset = earliestResult.getOffset();
-            long logStartTimestamp = earliestResult.getTimestamp();
-
-            // logEndOffset is ALWAYS the true end-of-log (LATEST). This is the boundary
-            // for lag = logEndOffset - committedOffset, throughput, and retention.
-            long logEndOffset = latestOffsetResult.getOffset();
-
-            // The timestamp anchor comes from MAX_TIMESTAMP (offset of the highest-timestamp
-            // record). This offset can be < logEndOffset, so carry it separately rather than
-            // overwriting logEndOffset, otherwise interpolation anchors and lag disagree.
-            long logEndTimestamp;
-            long maxTimestampOffset;
-
-            if (maxTimestampResult != null
-                && maxTimestampResult.getOffset() >= 0
-                && maxTimestampResult.getTimestamp() > 0) {
-              // MAX_TIMESTAMP returned a valid offset/timestamp anchor
-              maxTimestampOffset = maxTimestampResult.getOffset();
-              logEndTimestamp = maxTimestampResult.getTimestamp();
-            } else {
-              // MAX_TIMESTAMP missing/failed (pre-3.0 broker or no timestamps) - fall back to LATEST
-              maxTimestampOffset = latestOffsetResult.getOffset();
-              logEndTimestamp = latestOffsetResult.getTimestamp();
-            }
-
-            // Handle edge case: if earliest also returns -1, topic may be empty
-            if (logStartOffset < 0) {
-              logStartOffset = 0;
-              logStartTimestamp = -1;
-            }
-
-            // Log first partition's timestamps at INFO level for debugging
-            if (!loggedSampleTimestamp) {
-              log.info("Topic {} sample timestamps: partition {} logStart={} (ts={}), logEnd={}, maxTsOffset={} (ts={})",
-                topic, partition.partition(), logStartOffset, logStartTimestamp, logEndOffset, maxTimestampOffset, logEndTimestamp);
-              loggedSampleTimestamp = true;
-            } else {
-              log.debug("Topic {} partition {}: logStart={} (ts={}), logEnd={}, maxTsOffset={} (ts={})",
-                topic, partition.partition(), logStartOffset, logStartTimestamp, logEndOffset, maxTimestampOffset, logEndTimestamp);
-            }
-
-            result.add(new PartitionOffsets(topic, partition.partition(), logEndOffset, logStartOffset,
-              logEndTimestamp, maxTimestampOffset, logStartTimestamp,
-              partition.replicas().size(), partition.inSyncReplicas().size()));
-          }
-
-          log.info("Retrieved offsets for {} partitions of topic {}", result.size(), topic);
-          return Future.succeededFuture(result);
+          return Future.succeededFuture(assembleOffsets(partitionsByTopic, maxTimestampOffsets,
+            composite.resultAt(1), composite.resultAt(2)));
         });
       })
-      .onFailure(err -> log.error("Failed to get log end offsets for topic: {}", topic, err));
+      .onFailure(err -> log.error("Failed to get log end offsets for {} topics", topics.size(), err));
+  }
+
+  /**
+   * Turns the three raw listOffsets responses into {@link PartitionOffsets} grouped by topic.
+   *
+   * <p>Package-private and static so the offset/timestamp derivation — the MAX_TIMESTAMP
+   * fallback, the empty-partition edge case, the missing-partition skip — is testable without
+   * a broker or an admin client.
+   */
+  static Map<String, List<PartitionOffsets>> assembleOffsets(
+      Map<String, List<PartitionInfo>> partitionsByTopic,
+      Map<TopicPartition, ListOffsetsResultInfo> maxTimestampOffsets,
+      Map<TopicPartition, ListOffsetsResultInfo> earliestTimestampOffsets,
+      Map<TopicPartition, ListOffsetsResultInfo> latestOffsets) {
+
+    Map<String, List<PartitionOffsets>> byTopic = new HashMap<>();
+
+    partitionsByTopic.forEach((topic, partitions) -> {
+      List<PartitionOffsets> result = new ArrayList<>(partitions.size());
+
+      for (PartitionInfo partition : partitions) {
+        TopicPartition tp = new TopicPartition(topic, partition.partition());
+
+        ListOffsetsResultInfo earliestResult = earliestTimestampOffsets.get(tp);
+        ListOffsetsResultInfo maxTimestampResult = maxTimestampOffsets.get(tp);
+        ListOffsetsResultInfo latestOffsetResult = latestOffsets.get(tp);
+
+        // The partition list comes from a separate describeTopics call; a partition can
+        // be missing from a listOffsets response (leaderless partition, partition added
+        // mid-call, per-partition broker error). Skip it instead of NPEing the whole topic.
+        if (earliestResult == null || latestOffsetResult == null) {
+          log.warn("Missing listOffsets result for {}-{} (earliest={}, latest={}); skipping partition",
+            topic, partition.partition(), earliestResult != null, latestOffsetResult != null);
+          continue;
+        }
+
+        // Get earliest offset and timestamp from TIMESTAMP(0)
+        long logStartOffset = earliestResult.getOffset();
+        long logStartTimestamp = earliestResult.getTimestamp();
+
+        // logEndOffset is ALWAYS the true end-of-log (LATEST). This is the boundary
+        // for lag = logEndOffset - committedOffset, throughput, and retention.
+        long logEndOffset = latestOffsetResult.getOffset();
+
+        // The timestamp anchor comes from MAX_TIMESTAMP (offset of the highest-timestamp
+        // record). This offset can be < logEndOffset, so carry it separately rather than
+        // overwriting logEndOffset, otherwise interpolation anchors and lag disagree.
+        long logEndTimestamp;
+        long maxTimestampOffset;
+
+        if (maxTimestampResult != null
+            && maxTimestampResult.getOffset() >= 0
+            && maxTimestampResult.getTimestamp() > 0) {
+          // MAX_TIMESTAMP returned a valid offset/timestamp anchor
+          maxTimestampOffset = maxTimestampResult.getOffset();
+          logEndTimestamp = maxTimestampResult.getTimestamp();
+        } else {
+          // MAX_TIMESTAMP missing/failed (pre-3.0 broker or no timestamps) - fall back to LATEST
+          maxTimestampOffset = latestOffsetResult.getOffset();
+          logEndTimestamp = latestOffsetResult.getTimestamp();
+        }
+
+        // Handle edge case: if earliest also returns -1, topic may be empty
+        if (logStartOffset < 0) {
+          logStartOffset = 0;
+          logStartTimestamp = -1;
+        }
+
+        log.debug("Topic {} partition {}: logStart={} (ts={}), logEnd={}, maxTsOffset={} (ts={})",
+          topic, partition.partition(), logStartOffset, logStartTimestamp, logEndOffset,
+          maxTimestampOffset, logEndTimestamp);
+
+        result.add(new PartitionOffsets(topic, partition.partition(), logEndOffset, logStartOffset,
+          logEndTimestamp, maxTimestampOffset, logStartTimestamp,
+          partition.replicas().size(), partition.inSyncReplicas().size()));
+      }
+
+      byTopic.put(topic, result);
+    });
+
+    return byTopic;
   }
 
   @Override
@@ -292,7 +352,7 @@ public class KafkaClientServiceImpl implements KafkaClientService {
       lastMissingByGroup.remove(groupId);
     }
 
-    log.info("Retrieved {} partition offsets for consumer group {}", offsetMap.size(), groupId);
+    log.debug("Retrieved {} partition offsets for consumer group {}", offsetMap.size(), groupId);
     return new ConsumerGroupOffsets(groupId, offsetMap);
   }
 
@@ -317,7 +377,7 @@ public class KafkaClientServiceImpl implements KafkaClientService {
         // ephemeral group IDs (console-consumer-*, CI runs) leak entries for the
         // process lifetime.
         lastMissingByGroup.keySet().retainAll(groups);
-        log.info("Listed {} consumer groups", groups.size());
+        log.debug("Listed {} consumer groups", groups.size());
       })
       .onFailure(err -> log.error("Failed to list consumer groups", err));
   }
@@ -340,7 +400,7 @@ public class KafkaClientServiceImpl implements KafkaClientService {
           result.put(groupId, new ConsumerGroupState(groupId, state, partitionOwners(description)));
           log.debug("Consumer group {} state: {}", groupId, state);
         });
-        log.info("Described {} consumer groups", result.size());
+        log.debug("Described {} consumer groups", result.size());
         return result;
       })
       .onFailure(err -> log.error("Failed to describe consumer groups", err));
@@ -416,13 +476,26 @@ public class KafkaClientServiceImpl implements KafkaClientService {
       .onFailure(err -> log.error("Failed to close Kafka admin client", err));
   }
 
-  private PartitionInfo toPartitionInfo(String topic, TopicPartitionInfo tpi) {
+  // Kafka reports a null leader for offline partitions, and can report null replica/ISR
+  // lists alongside it. Dereferencing those blindly throws inside the describeTopics
+  // mapper, which would fail the whole batched fetch — one offline partition anywhere in
+  // the cluster would blind every topic for the cycle. Degrade instead: leader -1, empty
+  // replica/ISR lists. An empty replica list yields replicaCount 0, which detectUnderReplicated
+  // correctly ignores (0 < 0 is false) rather than reporting a phantom under-replication.
+  static PartitionInfo toPartitionInfo(String topic, TopicPartitionInfo tpi) {
     return new PartitionInfo(
       topic,
       tpi.getPartition(),
-      tpi.getLeader().getId(),
-      tpi.getReplicas().stream().map(node -> node.getId()).collect(Collectors.toList()),
-      tpi.getIsr().stream().map(node -> node.getId()).collect(Collectors.toList())
+      tpi.getLeader() != null ? tpi.getLeader().getId() : -1,
+      nodeIds(tpi.getReplicas()),
+      nodeIds(tpi.getIsr())
     );
+  }
+
+  private static List<Integer> nodeIds(List<io.vertx.kafka.client.common.Node> nodes) {
+    if (nodes == null) {
+      return List.of();
+    }
+    return nodes.stream().map(node -> node.getId()).collect(Collectors.toList());
   }
 }

--- a/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
+++ b/src/main/java/io/github/themoah/klag/kafka/KafkaClientServiceImpl.java
@@ -395,8 +395,11 @@ public class KafkaClientServiceImpl implements KafkaClientService {
       .map(descriptions -> {
         Map<String, ConsumerGroupState> result = new HashMap<>();
         descriptions.forEach((groupId, description) -> {
+          // Pass the name, not the enum: kafka-clients 4.x deprecated ConsumerGroupState
+          // for removal, but the Vert.x wrapper still returns it. See State#fromKafkaState.
+          var kafkaState = description.getState();
           ConsumerGroupState.State state = ConsumerGroupState.State
-              .fromKafkaState(description.getState());
+              .fromKafkaState(kafkaState == null ? null : kafkaState.name());
           result.put(groupId, new ConsumerGroupState(groupId, state, partitionOwners(description)));
           log.debug("Consumer group {} state: {}", groupId, state);
         });

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -1,5 +1,6 @@
 package io.github.themoah.klag.metrics;
 
+import io.github.themoah.klag.config.Env;
 import io.github.themoah.klag.kafka.ChunkConfig;
 import io.github.themoah.klag.kafka.ChunkProcessor;
 import io.github.themoah.klag.kafka.KafkaClientService;
@@ -54,6 +55,11 @@ public class MetricsCollector {
 
   private static final Logger log = LoggerFactory.getLogger(MetricsCollector.class);
 
+  // Caps how many groups have a committed-offset request in flight at once. Purely a
+  // concurrency bound, not a throttle — see fetchGroupOffsets.
+  private static final String ENV_MAX_CONCURRENT_GROUPS = "KAFKA_MAX_CONCURRENT_GROUPS";
+  private static final int DEFAULT_MAX_CONCURRENT_GROUPS = 50;
+
   private final Vertx vertx;
   private final KafkaClientService kafkaClient;
   private final MicrometerReporter reporter;
@@ -66,6 +72,7 @@ public class MetricsCollector {
   private final CommitFreshnessTracker commitFreshnessTracker;  // null when disabled
   private final boolean isrEnabled;
   private final ChunkConfig chunkConfig;
+  private final int maxConcurrentGroups;
 
   private final Map<String, Integer> cachedGroupPartitionCounts = new ConcurrentHashMap<>();
   private final Map<String, Integer> cachedTopicPartitionCounts = new ConcurrentHashMap<>();
@@ -164,6 +171,8 @@ public class MetricsCollector {
       : null;
     this.isrEnabled = IsrConfig.fromEnvironment().enabled();
     this.chunkConfig = chunkConfig;
+    this.maxConcurrentGroups = Math.max(1,
+      Env.getInt(ENV_MAX_CONCURRENT_GROUPS, DEFAULT_MAX_CONCURRENT_GROUPS));
   }
 
   /**
@@ -275,7 +284,7 @@ public class MetricsCollector {
    * Original non-chunked path: collects all groups in parallel.
    */
   private Future<Void> collectAllGroupsParallel(Set<String> filteredGroups) {
-    Future<List<ConsumerGroupLag>> lagFuture = collectAllGroupLags(filteredGroups);
+    Future<List<ConsumerGroupLag>> lagFuture = collectGroupLags(filteredGroups);
     Future<Map<String, ConsumerGroupState>> stateFuture =
         kafkaClient.describeConsumerGroups(filteredGroups);
 
@@ -322,13 +331,7 @@ public class MetricsCollector {
   private Future<Void> processGroupChunk(List<String> chunk, CycleState cycle) {
     log.debug("Processing group chunk with {} groups", chunk.size());
 
-    Future<List<ConsumerGroupLag>> lagFuture;
-    if (chunkConfig.isChunkingEnabled()) {
-      lagFuture = collectGroupLagsChunked(chunk);
-    } else {
-      lagFuture = collectAllGroupLags(new HashSet<>(chunk));
-    }
-
+    Future<List<ConsumerGroupLag>> lagFuture = collectGroupLags(chunk);
     Future<Map<String, ConsumerGroupState>> stateFuture =
         kafkaClient.describeConsumerGroups(new HashSet<>(chunk));
 
@@ -387,106 +390,27 @@ public class MetricsCollector {
   }
 
   /**
-   * Collects lag for a list of groups with topic-level chunking.
+   * Collects lag for a set of groups in two phases.
+   *
+   * <p>Phase 1 fetches every group's committed offsets (bounded fan-out). Phase 2 takes the
+   * union of the topics those groups consume and resolves all of them in a single batched
+   * call. That batching is the point: fetching offsets per topic cost four admin requests
+   * per topic per cycle, so a few hundred topics meant hundreds of round-trips and cycles
+   * that overran the interval. The batched fetch costs four for the whole set.
+   *
+   * <p>Phase 3 is pure assembly — no I/O — because every group's topics are already resolved.
    */
-  private Future<List<ConsumerGroupLag>> collectGroupLagsChunked(List<String> groups) {
-    List<Future<ConsumerGroupLag>> futures = groups.stream()
-      .map(this::collectGroupLagChunked)
-      .collect(Collectors.toList());
-
-    return Future.all(futures)
-      .map(composite -> {
-        List<ConsumerGroupLag> results = new ArrayList<>();
-        for (int i = 0; i < composite.size(); i++) {
-          ConsumerGroupLag lag = composite.resultAt(i);
-          if (lag != null) {
-            results.add(lag);
-          }
-        }
-        return results;
-      });
-  }
-
-  /**
-   * Collects lag for a single group with topic-level chunking for log end offset fetches.
-   */
-  private Future<ConsumerGroupLag> collectGroupLagChunked(String groupId) {
-    return kafkaClient.getConsumerGroupOffsets(groupId)
-      .compose(offsets -> {
-        Set<String> topics = offsets.offsets().keySet().stream()
+  private Future<List<ConsumerGroupLag>> collectGroupLags(Collection<String> groups) {
+    return fetchGroupOffsets(groups)
+      .compose(offsetsByGroup -> {
+        Set<String> topics = offsetsByGroup.values().stream()
+          .flatMap(offsets -> offsets.offsets().keySet().stream())
           .map(TopicPartitionKey::topic)
           .collect(Collectors.toSet());
 
-        if (topics.isEmpty()) {
-          return Future.succeededFuture(ConsumerGroupLag.fromPartitions(groupId, List.of()));
-        }
-
-        // Balance topics into chunks
-        List<List<String>> topicChunks = ChunkProcessor.balanceIntoChunks(
-          topics, chunkConfig.chunkCount(),
-          topic -> cachedTopicPartitionCounts.getOrDefault(topic, 1));
-
-        // Process topic chunks sequentially, each chunk fetches offsets in parallel
-        return ChunkProcessor.<String, List<PartitionOffsets>>processSequentially(
-          vertx, topicChunks, chunkConfig.chunkDelayMs(),
-          topicChunk -> {
-            List<Future<List<PartitionOffsets>>> offsetFutures = topicChunk.stream()
-              .map(this::getLogEndOffsetsCached)
-              .collect(Collectors.toList());
-
-            return Future.all(offsetFutures)
-              .map(composite -> {
-                List<PartitionOffsets> merged = new ArrayList<>();
-                for (int i = 0; i < composite.size(); i++) {
-                  List<PartitionOffsets> partitionOffsets = composite.resultAt(i);
-                  merged.addAll(partitionOffsets);
-                }
-                return merged;
-              });
-          }
-        ).map(chunkResults -> {
-          // Merge all partition offsets from all topic chunks
-          Map<TopicPartitionKey, PartitionOffsets> topicOffsets = new HashMap<>();
-          for (List<PartitionOffsets> chunkResult : chunkResults) {
-            for (PartitionOffsets po : chunkResult) {
-              TopicPartitionKey key = new TopicPartitionKey(po.topic(), po.partition());
-              topicOffsets.put(key, po);
-            }
-          }
-
-          // Update cached topic partition counts with actual partition counts
-          Map<String, Integer> topicPartitionCounts = new HashMap<>();
-          for (PartitionOffsets po : topicOffsets.values()) {
-            topicPartitionCounts.merge(po.topic(), 1, Integer::sum);
-          }
-          cachedTopicPartitionCounts.putAll(topicPartitionCounts);
-
-          return buildConsumerGroupLag(groupId, offsets, topicOffsets);
-        });
-      })
-      // Same recovery as collectGroupLag: a single failed group must not abort the chunk.
-      .recover(err -> {
-        log.warn("Failed to collect lag for group {} (skipped this cycle): {}",
-          groupId, err.getMessage());
-        return Future.succeededFuture(null);
-      });
-  }
-
-  private Future<List<ConsumerGroupLag>> collectAllGroupLags(Set<String> groups) {
-    List<Future<ConsumerGroupLag>> futures = groups.stream()
-      .map(this::collectGroupLag)
-      .collect(Collectors.toList());
-
-    return Future.all(futures)
-      .map(composite -> {
-        List<ConsumerGroupLag> results = new ArrayList<>();
-        for (int i = 0; i < composite.size(); i++) {
-          ConsumerGroupLag lag = composite.resultAt(i);
-          if (lag != null) {
-            results.add(lag);
-          }
-        }
-        return results;
+        return fetchTopicOffsets(topics).map(topicOffsets -> offsetsByGroup.entrySet().stream()
+          .map(entry -> buildConsumerGroupLag(entry.getKey(), entry.getValue(), topicOffsets))
+          .collect(Collectors.toList()));
       });
   }
 
@@ -639,51 +563,115 @@ public class MetricsCollector {
     log.debug("Reported metrics for {} consumer groups", lagData.size());
   }
 
-  private Future<ConsumerGroupLag> collectGroupLag(String groupId) {
-    return kafkaClient.getConsumerGroupOffsets(groupId)
-      .compose(offsets -> {
-        Set<String> topics = offsets.offsets().keySet().stream()
-          .map(TopicPartitionKey::topic)
-          .collect(Collectors.toSet());
+  /**
+   * Phase 1: committed offsets for every group, in waves of at most
+   * {@code maxConcurrentGroups}.
+   *
+   * <p>Without the bound, every group's {@code listConsumerGroupOffsets} is in flight at
+   * once; on a cluster with thousands of groups that saturates the admin client's request
+   * queue and the group coordinators. The waves have no delay between them — this bounds
+   * concurrency, it is not a throttle. {@code KAFKA_CHUNK_COUNT}/{@code KAFKA_CHUNK_DELAY_MS}
+   * remain the explicit broker-load throttle.
+   *
+   * @return group ID to its committed offsets; groups that failed are absent
+   */
+  private Future<Map<String, ConsumerGroupOffsets>> fetchGroupOffsets(Collection<String> groups) {
+    Map<String, ConsumerGroupOffsets> byGroup = new HashMap<>();
 
-        if (topics.isEmpty()) {
-          return Future.succeededFuture(ConsumerGroupLag.fromPartitions(groupId, List.of()));
-        }
-
-        // Get log end offsets for all topics the group is consuming
-        List<Future<List<PartitionOffsets>>> offsetFutures = topics.stream()
-          .map(this::getLogEndOffsetsCached)
+    return ChunkProcessor.<String, Void>processSequentially(
+      vertx, waves(groups, maxConcurrentGroups), 0,
+      wave -> {
+        List<Future<ConsumerGroupOffsets>> futures = wave.stream()
+          // Recover to null so one failing group (deleted mid-cycle, coordinator hiccup,
+          // ACL gap) is skipped rather than failing the wave and aborting the cycle for
+          // every other group.
+          .map(groupId -> kafkaClient.getConsumerGroupOffsets(groupId)
+            .recover(err -> {
+              log.warn("Failed to collect lag for group {} (skipped this cycle): {}",
+                groupId, err.getMessage());
+              return Future.succeededFuture(null);
+            }))
           .collect(Collectors.toList());
 
-        return Future.all(offsetFutures)
-          .map(composite -> {
-            Map<TopicPartitionKey, PartitionOffsets> topicOffsets = new HashMap<>();
-            for (int i = 0; i < composite.size(); i++) {
-              List<PartitionOffsets> partitionOffsets = composite.resultAt(i);
-              for (PartitionOffsets po : partitionOffsets) {
-                TopicPartitionKey key = new TopicPartitionKey(po.topic(), po.partition());
-                topicOffsets.put(key, po);
-              }
+        return Future.all(futures).<Void>map(composite -> {
+          for (int i = 0; i < composite.size(); i++) {
+            ConsumerGroupOffsets offsets = composite.resultAt(i);
+            if (offsets != null) {
+              byGroup.put(wave.get(i), offsets);
             }
-            return buildConsumerGroupLag(groupId, offsets, topicOffsets);
-          });
-      })
-      // Recover to null so one failing group (deleted mid-cycle, coordinator hiccup, ACL gap)
-      // is skipped by the null-filter in collectAllGroupLags instead of failing Future.all
-      // and aborting the whole cycle for every other group.
-      .recover(err -> {
-        log.warn("Failed to collect lag for group {} (skipped this cycle): {}",
-          groupId, err.getMessage());
-        return Future.succeededFuture(null);
-      });
+          }
+          return null;
+        });
+      }
+    ).map(v -> byGroup);
   }
 
   /**
-   * Per-cycle cached variant of {@link KafkaClientService#getLogEndOffsets(String)}.
-   * Multiple groups consuming the same topic reuse one in-flight (or completed) future.
+   * Phase 2: resolves every topic in one batched fetch and fills {@link #cycleTopicOffsets}.
+   *
+   * <p>When chunking is enabled the union is split into {@code chunkCount} batches processed
+   * sequentially with the configured delay, so the load-spreading knob still works — it now
+   * spreads a handful of batched calls instead of four calls per topic.
+   *
+   * <p>A failure here fails the cycle (or marks the chunk partial) rather than silently
+   * yielding empty lag: {@link #finishCycle} is then skipped and existing gauges are kept.
+   * Stale values beat deleting live series over a transient broker error.
+   *
+   * @return flattened topic-partition to offsets lookup for lag assembly
    */
-  private Future<List<PartitionOffsets>> getLogEndOffsetsCached(String topic) {
-    return cycleTopicOffsets.computeIfAbsent(topic, kafkaClient::getLogEndOffsets);
+  private Future<Map<TopicPartitionKey, PartitionOffsets>> fetchTopicOffsets(Set<String> topics) {
+    Map<TopicPartitionKey, PartitionOffsets> merged = new HashMap<>();
+
+    // With chunking on this runs once per group chunk, and chunks routinely share topics.
+    // Reuse whatever an earlier chunk already resolved this cycle instead of refetching it.
+    Set<String> missing = new HashSet<>();
+    for (String topic : topics) {
+      Future<List<PartitionOffsets>> resolved = cycleTopicOffsets.get(topic);
+      if (resolved != null && resolved.succeeded()) {
+        index(merged, resolved.result());
+      } else {
+        missing.add(topic);
+      }
+    }
+    if (missing.isEmpty()) {
+      return Future.succeededFuture(merged);
+    }
+
+    List<List<String>> topicChunks = chunkConfig.isChunkingEnabled()
+      ? ChunkProcessor.balanceIntoChunks(missing, chunkConfig.chunkCount(),
+          topic -> cachedTopicPartitionCounts.getOrDefault(topic, 1))
+      : List.of(new ArrayList<>(missing));
+
+    return ChunkProcessor.<String, Void>processSequentially(
+      vertx, topicChunks, chunkConfig.chunkDelayMs(),
+      chunk -> kafkaClient.getLogEndOffsets(new HashSet<>(chunk)).<Void>map(byTopic -> {
+        byTopic.forEach((topic, partitions) -> {
+          // Publish as a completed future: the ISR check reads cycleTopicOffsets and treats
+          // an absent or failed entry as "metadata unavailable, skip this topic".
+          cycleTopicOffsets.put(topic, Future.succeededFuture(partitions));
+          cachedTopicPartitionCounts.put(topic, partitions.size());
+          index(merged, partitions);
+        });
+        return null;
+      })
+    ).map(v -> merged);
+  }
+
+  private static void index(
+      Map<TopicPartitionKey, PartitionOffsets> target, List<PartitionOffsets> partitions) {
+    for (PartitionOffsets po : partitions) {
+      target.put(new TopicPartitionKey(po.topic(), po.partition()), po);
+    }
+  }
+
+  /** Splits items into consecutive groups of at most {@code size}. */
+  private static <T> List<List<T>> waves(Collection<T> items, int size) {
+    List<T> all = new ArrayList<>(items);
+    List<List<T>> waves = new ArrayList<>();
+    for (int i = 0; i < all.size(); i += size) {
+      waves.add(all.subList(i, Math.min(i + size, all.size())));
+    }
+    return waves;
   }
 
   private ConsumerGroupLag buildConsumerGroupLag(

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -893,7 +893,7 @@ public class MetricsCollector {
       log.debug("Skipped {} partitions with no lag_ms estimate", skippedPartitions);
     }
     if (!lagMsList.isEmpty()) {
-      log.info("Calculated lag_ms for {} consumer-group/topic pairs", lagMsList.size());
+      log.debug("Calculated lag_ms for {} consumer-group/topic pairs", lagMsList.size());
     }
 
     return lagMsList;

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -284,11 +284,11 @@ public class MetricsCollector {
    * Original non-chunked path: collects all groups in parallel.
    */
   private Future<Void> collectAllGroupsParallel(Set<String> filteredGroups) {
-    Future<List<ConsumerGroupLag>> lagFuture = collectGroupLags(filteredGroups);
+    CycleState cycle = new CycleState(newCycleSnapshot());
+    Future<List<ConsumerGroupLag>> lagFuture = collectGroupLags(filteredGroups, cycle);
     Future<Map<String, ConsumerGroupState>> stateFuture =
         kafkaClient.describeConsumerGroups(filteredGroups);
 
-    CycleState cycle = new CycleState(newCycleSnapshot());
     return Future.all(lagFuture, stateFuture)
       .map(composite -> {
         List<ConsumerGroupLag> lagData = composite.resultAt(0);
@@ -331,7 +331,7 @@ public class MetricsCollector {
   private Future<Void> processGroupChunk(List<String> chunk, CycleState cycle) {
     log.debug("Processing group chunk with {} groups", chunk.size());
 
-    Future<List<ConsumerGroupLag>> lagFuture = collectGroupLags(chunk);
+    Future<List<ConsumerGroupLag>> lagFuture = collectGroupLags(chunk, cycle);
     Future<Map<String, ConsumerGroupState>> stateFuture =
         kafkaClient.describeConsumerGroups(new HashSet<>(chunk));
 
@@ -364,13 +364,13 @@ public class MetricsCollector {
    * retainAll against the keys observed in the whole cycle: running any of them with a
    * chunk-local subset wipes the accumulated state of every other chunk.
    *
-   * <p>Partial cycles (a chunk failed) skip cleanup and publish entirely: the failed
-   * chunk's keys are missing from the accumulators, and cleaning up against an incomplete
+   * <p>Partial cycles (a chunk or a single group failed) skip cleanup and publish entirely:
+   * the failed keys are missing from the accumulators, and cleaning up against an incomplete
    * key set would mark or delete live series. Stale values beat deleted series.
    */
   private void finishCycle(CycleState cycle) {
     if (cycle.partial) {
-      log.warn("Collection cycle was partial (at least one chunk failed); "
+      log.warn("Collection cycle was partial (at least one chunk or group failed); "
         + "keeping previous metrics and skipping stale cleanup until a full cycle succeeds");
       return;
     }
@@ -400,8 +400,9 @@ public class MetricsCollector {
    *
    * <p>Phase 3 is pure assembly — no I/O — because every group's topics are already resolved.
    */
-  private Future<List<ConsumerGroupLag>> collectGroupLags(Collection<String> groups) {
-    return fetchGroupOffsets(groups)
+  private Future<List<ConsumerGroupLag>> collectGroupLags(
+      Collection<String> groups, CycleState cycle) {
+    return fetchGroupOffsets(groups, cycle)
       .compose(offsetsByGroup -> {
         Set<String> topics = offsetsByGroup.values().stream()
           .flatMap(offsets -> offsets.offsets().keySet().stream())
@@ -575,7 +576,8 @@ public class MetricsCollector {
    *
    * @return group ID to its committed offsets; groups that failed are absent
    */
-  private Future<Map<String, ConsumerGroupOffsets>> fetchGroupOffsets(Collection<String> groups) {
+  private Future<Map<String, ConsumerGroupOffsets>> fetchGroupOffsets(
+      Collection<String> groups, CycleState cycle) {
     Map<String, ConsumerGroupOffsets> byGroup = new HashMap<>();
 
     return ChunkProcessor.<String, Void>processSequentially(
@@ -584,9 +586,12 @@ public class MetricsCollector {
         List<Future<ConsumerGroupOffsets>> futures = wave.stream()
           // Recover to null so one failing group (deleted mid-cycle, coordinator hiccup,
           // ACL gap) is skipped rather than failing the wave and aborting the cycle for
-          // every other group.
+          // every other group. The cycle is marked partial: a skipped group's keys are
+          // absent from the accumulators, so the retainAll cleanups in finishCycle would
+          // delete its live series instead of holding the last good values.
           .map(groupId -> kafkaClient.getConsumerGroupOffsets(groupId)
             .recover(err -> {
+              cycle.partial = true;
               log.warn("Failed to collect lag for group {} (skipped this cycle): {}",
                 groupId, err.getMessage());
               return Future.succeededFuture(null);

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -203,8 +203,11 @@ public class MetricsCollector {
     log.info("Starting metrics collector with interval: {}ms, filter: {}, exclude: {}",
       intervalMs, groupFilter.includeDescription(), groupFilter.excludeDescription());
 
+    // The first cycle is recovered: a broker that is down at boot must degrade (like
+    // KafkaHealthMonitor) instead of failing verticle startup, which exits the process
+    // and crash-loops under Kubernetes. collectAndReport already logs the cause.
     return reporter.start()
-      .compose(v -> collectAndReport())
+      .compose(v -> collectAndReport().recover(err -> Future.succeededFuture()))
       .onComplete(ar -> {
         timerId = vertx.setPeriodic(intervalMs, id -> {
           if (collectionInFlight) {
@@ -247,11 +250,10 @@ public class MetricsCollector {
           groups.size(), filteredGroups.size());
 
         if (filteredGroups.isEmpty()) {
-          reporter.cleanupStaleGauges(Set.of());
-          reporter.cleanupStateTracker(Set.of());
-          if (commitFreshnessTracker != null) {
-            commitFreshnessTracker.cleanupStale(Set.of());
-          }
+          // Same cycle-end path as a normal cycle, with empty key sets: every tracker
+          // drains and the MCP snapshot refreshes to empty instead of staying frozen
+          // at the last non-empty cycle.
+          finishCycle(new CycleState(newCycleSnapshot()));
           return Future.succeededFuture();
         }
 
@@ -449,8 +451,6 @@ public class MetricsCollector {
             for (PartitionOffsets po : chunkResult) {
               TopicPartitionKey key = new TopicPartitionKey(po.topic(), po.partition());
               topicOffsets.put(key, po);
-              // Update cached topic partition counts
-              cachedTopicPartitionCounts.merge(po.topic(), 1, Integer::max);
             }
           }
 

--- a/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MetricsCollector.java
@@ -83,6 +83,11 @@ public class MetricsCollector {
   private final Map<String, Future<List<PartitionOffsets>>> cycleTopicOffsets =
       new ConcurrentHashMap<>();
 
+  // Per-cycle cache of the cluster's topic names, used to drop deleted topics before
+  // describeTopics sees them. One list call per cycle, not per chunk. Cleared with
+  // cycleTopicOffsets; a failed lookup stays cached so the cycle fails once, not per chunk.
+  private Future<Set<String>> cycleTopicNames;
+
   // Guards against overlapping collection cycles when a cycle exceeds the interval
   // (large clusters, chunk delays). Only touched on the Vert.x event loop.
   private boolean collectionInFlight;
@@ -247,6 +252,7 @@ public class MetricsCollector {
     log.debug("Collecting lag metrics");
     collectionInFlight = true;
     cycleTopicOffsets.clear();
+    cycleTopicNames = null;
     long cycleStartNanos = System.nanoTime();
 
     return kafkaClient.listConsumerGroups()
@@ -364,14 +370,23 @@ public class MetricsCollector {
    * retainAll against the keys observed in the whole cycle: running any of them with a
    * chunk-local subset wipes the accumulated state of every other chunk.
    *
-   * <p>Partial cycles (a chunk or a single group failed) skip cleanup and publish entirely:
-   * the failed keys are missing from the accumulators, and cleaning up against an incomplete
-   * key set would mark or delete live series. Stale values beat deleted series.
+   * <p>Partial cycles (a chunk or a single group failed) skip cleanup: the failed keys are
+   * missing from the accumulators, and cleaning up against an incomplete key set would mark
+   * or delete live series. Stale values beat deleted series. Note this means a permanently
+   * failing group (ACL gap, wedged coordinator) freezes cleanup indefinitely — the WARN below
+   * names the group; fix its ACL or exclude it via METRICS_GROUP_EXCLUDE.
+   *
+   * <p>The MCP snapshot still publishes on a partial cycle, because freezing it would leave
+   * agents reading hours-old data while /metrics stays current. The exception is an empty
+   * snapshot: nothing was collected at all, and wiping the agent view is worse than a stale one.
    */
   private void finishCycle(CycleState cycle) {
     if (cycle.partial) {
       log.warn("Collection cycle was partial (at least one chunk or group failed); "
         + "keeping previous metrics and skipping stale cleanup until a full cycle succeeds");
+      if (cycle.snapshot != null && !cycle.snapshot.groups.isEmpty()) {
+        publishSnapshot(cycle.snapshot);
+      }
       return;
     }
     velocityTracker.cleanupStaleTopics(cycle.velocityKeys);
@@ -622,6 +637,14 @@ public class MetricsCollector {
    * yielding empty lag: {@link #finishCycle} is then skipped and existing gauges are kept.
    * Stale values beat deleting live series over a transient broker error.
    *
+   * <p>Topics are first filtered against the cluster's topic list. The Vert.x admin wrapper
+   * resolves describeTopics through {@code allTopicNames()}, so a single unknown topic fails
+   * the whole batch — and a group's committed offsets outlive a deleted topic until
+   * {@code offsets.retention.minutes} (7 days by default), which would keep every cycle
+   * partial, and therefore stale-gauge cleanup frozen, for that long. Dropping the topic here
+   * makes deletion look like deletion: its series go missing from the cycle's key set and are
+   * retired within 1-2 cycles.
+   *
    * @return flattened topic-partition to offsets lookup for lag assembly
    */
   private Future<Map<TopicPartitionKey, PartitionOffsets>> fetchTopicOffsets(Set<String> topics) {
@@ -642,24 +665,49 @@ public class MetricsCollector {
       return Future.succeededFuture(merged);
     }
 
-    List<List<String>> topicChunks = chunkConfig.isChunkingEnabled()
-      ? ChunkProcessor.balanceIntoChunks(missing, chunkConfig.chunkCount(),
-          topic -> cachedTopicPartitionCounts.getOrDefault(topic, 1))
-      : List.of(new ArrayList<>(missing));
+    // A failed listTopics propagates: filtering must never silently fall through unfiltered,
+    // which is what reintroduces the week-long cleanup freeze.
+    return clusterTopics().compose(existing -> {
+      Set<String> gone = new HashSet<>(missing);
+      gone.removeAll(existing);
+      if (!gone.isEmpty()) {
+        // Also covers topics the principal cannot see: with asymmetric ACLs (group offsets
+        // readable, topic not) klag cannot tell that apart from deletion and retires the series.
+        log.info("Skipping {} topic(s) absent from the cluster topic list (deleted or not "
+          + "visible to this principal); their series are retired: {}", gone.size(), gone);
+        missing.removeAll(gone);
+      }
+      if (missing.isEmpty()) {
+        return Future.succeededFuture(merged);
+      }
 
-    return ChunkProcessor.<String, Void>processSequentially(
-      vertx, topicChunks, chunkConfig.chunkDelayMs(),
-      chunk -> kafkaClient.getLogEndOffsets(new HashSet<>(chunk)).<Void>map(byTopic -> {
-        byTopic.forEach((topic, partitions) -> {
-          // Publish as a completed future: the ISR check reads cycleTopicOffsets and treats
-          // an absent or failed entry as "metadata unavailable, skip this topic".
-          cycleTopicOffsets.put(topic, Future.succeededFuture(partitions));
-          cachedTopicPartitionCounts.put(topic, partitions.size());
-          index(merged, partitions);
-        });
-        return null;
-      })
-    ).map(v -> merged);
+      List<List<String>> topicChunks = chunkConfig.isChunkingEnabled()
+        ? ChunkProcessor.balanceIntoChunks(missing, chunkConfig.chunkCount(),
+            topic -> cachedTopicPartitionCounts.getOrDefault(topic, 1))
+        : List.of(new ArrayList<>(missing));
+
+      return ChunkProcessor.<String, Void>processSequentially(
+        vertx, topicChunks, chunkConfig.chunkDelayMs(),
+        chunk -> kafkaClient.getLogEndOffsets(new HashSet<>(chunk)).<Void>map(byTopic -> {
+          byTopic.forEach((topic, partitions) -> {
+            // Publish as a completed future: the ISR check reads cycleTopicOffsets and treats
+            // an absent or failed entry as "metadata unavailable, skip this topic".
+            cycleTopicOffsets.put(topic, Future.succeededFuture(partitions));
+            cachedTopicPartitionCounts.put(topic, partitions.size());
+            index(merged, partitions);
+          });
+          return null;
+        })
+      ).map(v -> merged);
+    });
+  }
+
+  /** Cluster topic names, fetched at most once per cycle and shared by every chunk. */
+  private Future<Set<String>> clusterTopics() {
+    if (cycleTopicNames == null) {
+      cycleTopicNames = kafkaClient.listTopics();
+    }
+    return cycleTopicNames;
   }
 
   private static void index(
@@ -938,7 +986,8 @@ public class MetricsCollector {
    *
    * <p>Each set gathers the keys observed across all chunks so the retainAll-based
    * cleanups in {@link #finishCycle(CycleState)} see the complete cycle. {@code partial}
-   * is set when a chunk fails, which suppresses cleanup and snapshot publish for the cycle.
+   * is set when a chunk fails, which suppresses cleanup for the cycle (the snapshot still
+   * publishes unless it is empty).
    */
   private static class CycleState {
     final Set<String> activeKeys = new HashSet<>();

--- a/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionDetector.java
+++ b/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionDetector.java
@@ -3,6 +3,7 @@ package io.github.themoah.klag.metrics.hotpartition;
 import io.github.themoah.klag.metrics.hotpartition.StatisticalUtils.Stats;
 import io.github.themoah.klag.model.ConsumerGroupLag;
 import io.github.themoah.klag.model.ConsumerGroupLag.PartitionLag;
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
 import io.github.themoah.klag.model.HotPartitionLag;
 import io.github.themoah.klag.model.HotPartitionThroughput;
 import java.util.ArrayList;
@@ -127,24 +128,22 @@ public class HotPartitionDetector {
   public Set<String> recordThroughputSnapshots(List<ConsumerGroupLag> lagData) {
     Set<String> activeKeys = new HashSet<>();
 
-    // Track unique topic:partition combinations (avoid duplicates from multiple consumer groups)
-    Map<String, Long> partitionOffsets = new HashMap<>();
+    // Track unique topic/partition combinations (avoid duplicates from multiple consumer groups)
+    Map<TopicPartitionKey, Long> partitionOffsets = new HashMap<>();
 
     for (ConsumerGroupLag group : lagData) {
       for (PartitionLag partition : group.partitions()) {
-        String key = PartitionThroughputTracker.makeKey(partition.topic(), partition.partition());
+        TopicPartitionKey key = new TopicPartitionKey(partition.topic(), partition.partition());
         // Use the max offset if we see the same partition from multiple groups
         partitionOffsets.merge(key, partition.logEndOffset(), Long::max);
       }
     }
 
     // Record snapshots
-    for (Map.Entry<String, Long> entry : partitionOffsets.entrySet()) {
-      String[] parts = entry.getKey().split(":");
-      String topic = parts[0];
-      int partition = Integer.parseInt(parts[1]);
-      throughputTracker.recordSnapshot(topic, partition, entry.getValue());
-      activeKeys.add(entry.getKey());
+    for (Map.Entry<TopicPartitionKey, Long> entry : partitionOffsets.entrySet()) {
+      TopicPartitionKey key = entry.getKey();
+      throughputTracker.recordSnapshot(key.topic(), key.partition(), entry.getValue());
+      activeKeys.add(PartitionThroughputTracker.makeKey(key.topic(), key.partition()));
     }
 
     return activeKeys;
@@ -164,18 +163,8 @@ public class HotPartitionDetector {
   public List<HotPartitionThroughput> detectHotPartitionsByThroughput() {
     List<HotPartitionThroughput> hotPartitions = new ArrayList<>();
 
-    Map<String, Double> allThroughputs = throughputTracker.calculateAllThroughputs();
-
-    // Group by topic
-    Map<String, Map<Integer, Double>> throughputsByTopic = new HashMap<>();
-    for (Map.Entry<String, Double> entry : allThroughputs.entrySet()) {
-      String[] parts = entry.getKey().split(":");
-      String topic = parts[0];
-      int partition = Integer.parseInt(parts[1]);
-
-      throughputsByTopic.computeIfAbsent(topic, k -> new HashMap<>())
-        .put(partition, entry.getValue());
-    }
+    Map<String, Map<Integer, Double>> throughputsByTopic =
+        throughputTracker.calculateThroughputsByTopic();
 
     // Analyze each topic
     for (Map.Entry<String, Map<Integer, Double>> topicEntry : throughputsByTopic.entrySet()) {

--- a/src/main/java/io/github/themoah/klag/metrics/hotpartition/PartitionThroughputTracker.java
+++ b/src/main/java/io/github/themoah/klag/metrics/hotpartition/PartitionThroughputTracker.java
@@ -47,39 +47,22 @@ public class PartitionThroughputTracker {
   }
 
   /**
-   * Calculates current throughput rates for all partitions that have enough data.
+   * Calculates current throughput rates for all partitions that have enough data,
+   * grouped by topic.
    *
-   * @return map of "topic:partition" key to throughput (messages/second)
+   * <p>Topic and partition come from the retained history, never from parsing the map key:
+   * topic names may legally contain the key separator.
+   *
+   * @return map of topic to (partition number to throughput in messages/second)
    */
-  public Map<String, Double> calculateAllThroughputs() {
-    Map<String, Double> result = new HashMap<>();
+  public Map<String, Map<Integer, Double>> calculateThroughputsByTopic() {
+    Map<String, Map<Integer, Double>> result = new HashMap<>();
 
-    for (Map.Entry<String, PartitionThroughputHistory> entry : histories.entrySet()) {
-      Double throughput = entry.getValue().calculateThroughput();
+    for (PartitionThroughputHistory history : histories.values()) {
+      Double throughput = history.calculateThroughput();
       if (throughput != null && throughput >= 0) {
-        result.put(entry.getKey(), throughput);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Gets all throughput rates for a specific topic.
-   *
-   * @param topic the topic name
-   * @return map of partition number to throughput (only partitions with sufficient data)
-   */
-  public Map<Integer, Double> getThroughputsForTopic(String topic) {
-    Map<Integer, Double> result = new HashMap<>();
-
-    for (Map.Entry<String, PartitionThroughputHistory> entry : histories.entrySet()) {
-      PartitionThroughputHistory history = entry.getValue();
-      if (history.topic().equals(topic)) {
-        Double throughput = history.calculateThroughput();
-        if (throughput != null && throughput >= 0) {
-          result.put(history.partition(), throughput);
-        }
+        result.computeIfAbsent(history.topic(), k -> new HashMap<>())
+          .put(history.partition(), throughput);
       }
     }
 
@@ -102,6 +85,9 @@ public class PartitionThroughputTracker {
 
   /**
    * Creates a key for the partition history map.
+   *
+   * <p>The key is opaque: it is only ever compared, never parsed back into topic and
+   * partition (topic names may contain ':'). Read topic/partition off the history instead.
    *
    * @param topic the topic name
    * @param partition the partition number

--- a/src/main/java/io/github/themoah/klag/metrics/timelag/PartitionOffsetHistory.java
+++ b/src/main/java/io/github/themoah/klag/metrics/timelag/PartitionOffsetHistory.java
@@ -57,7 +57,8 @@ public class PartitionOffsetHistory {
 
     // Log when we first have enough data for interpolation
     if (!hasLoggedDataReady && points.size() >= MIN_POINTS_FOR_INTERPOLATION) {
-      log.info("Collected {} samples for {}:{} - interpolation now available",
+      // This message can be very noisy on big cluster
+      log.debug("Collected {} samples for {}:{} - interpolation now available",
         MIN_POINTS_FOR_INTERPOLATION, topic, partition);
       hasLoggedDataReady = true;
     }

--- a/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
+++ b/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
@@ -40,23 +40,27 @@ public record ConsumerGroupState(
     EMPTY;
 
     /**
-     * Converts from Kafka's ConsumerGroupState to this enum.
+     * Converts a Kafka group-state enum constant name to this enum.
      *
-     * @param kafkaState the Kafka consumer group state
-     * @return the corresponding State enum value
+     * <p>Takes the name rather than {@code org.apache.kafka.common.ConsumerGroupState} on
+     * purpose: that class is deprecated for removal in kafka-clients 4.x (superseded by
+     * {@code GroupState}), but the Vert.x admin wrapper still returns it. Matching on the
+     * name keeps klag off the removal path — when Vert.x switches to {@code GroupState},
+     * whose constants carry the same names, this needs no change. Names klag does not know
+     * (the new consumer protocol's {@code ASSIGNING}/{@code RECONCILING}) map to UNKNOWN.
+     *
+     * @param kafkaStateName the Kafka group state's enum constant name, may be null
+     * @return the corresponding State enum value, or UNKNOWN if unrecognised
      */
-    public static State fromKafkaState(org.apache.kafka.common.ConsumerGroupState kafkaState) {
-      if (kafkaState == null) {
+    public static State fromKafkaState(String kafkaStateName) {
+      if (kafkaStateName == null) {
         return UNKNOWN;
       }
-      return switch (kafkaState) {
-        case PREPARING_REBALANCE -> PREPARING_REBALANCE;
-        case COMPLETING_REBALANCE -> COMPLETING_REBALANCE;
-        case STABLE -> STABLE;
-        case DEAD -> DEAD;
-        case EMPTY -> EMPTY;
-        default -> UNKNOWN;
-      };
+      try {
+        return valueOf(kafkaStateName);
+      } catch (IllegalArgumentException e) {
+        return UNKNOWN;
+      }
     }
 
     /**

--- a/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
+++ b/src/main/java/io/github/themoah/klag/model/ConsumerGroupState.java
@@ -35,6 +35,11 @@ public record ConsumerGroupState(
     UNKNOWN,
     PREPARING_REBALANCE,
     COMPLETING_REBALANCE,
+    // KIP-848 (new consumer protocol) replaces the two rebalance states above with these.
+    // Kept as distinct tags rather than aliased onto the classic ones: separate values match
+    // what Kafka reports and keep alert semantics honest.
+    ASSIGNING,
+    RECONCILING,
     STABLE,
     DEAD,
     EMPTY;
@@ -47,7 +52,7 @@ public record ConsumerGroupState(
      * {@code GroupState}), but the Vert.x admin wrapper still returns it. Matching on the
      * name keeps klag off the removal path — when Vert.x switches to {@code GroupState},
      * whose constants carry the same names, this needs no change. Names klag does not know
-     * (the new consumer protocol's {@code ASSIGNING}/{@code RECONCILING}) map to UNKNOWN.
+     * map to UNKNOWN.
      *
      * @param kafkaStateName the Kafka group state's enum constant name, may be null
      * @return the corresponding State enum value, or UNKNOWN if unrecognised

--- a/src/test/java/io/github/themoah/klag/kafka/KafkaClientServiceImplBatchOffsetsTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/KafkaClientServiceImplBatchOffsetsTest.java
@@ -1,0 +1,159 @@
+package io.github.themoah.klag.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.themoah.klag.model.PartitionInfo;
+import io.github.themoah.klag.model.PartitionOffsets;
+import io.vertx.kafka.admin.ListOffsetsResultInfo;
+import io.vertx.kafka.client.common.Node;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.common.TopicPartitionInfo;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the batched offset assembly: one describeTopics + three listOffsets responses
+ * spanning many topics are turned into per-topic {@link PartitionOffsets}.
+ *
+ * <p>Exercises the pure derivation only — no admin client, no broker.
+ */
+class KafkaClientServiceImplBatchOffsetsTest {
+
+  private static final long NOW = 1_700_000_000_000L;
+
+  private static PartitionInfo partition(String topic, int partition) {
+    return new PartitionInfo(topic, partition, 1, List.of(1, 2, 3), List.of(1, 2, 3));
+  }
+
+  private static ListOffsetsResultInfo offset(long offset, long timestamp) {
+    return new ListOffsetsResultInfo(offset, timestamp, null);
+  }
+
+  private static Node node(int id) {
+    return new Node(false, "broker-" + id, id, String.valueOf(id), false, 9092, null);
+  }
+
+  @Test
+  @DisplayName("groups partitions of multiple topics by topic in one pass")
+  void assembleOffsets_groupsByTopic() {
+    Map<String, List<PartitionInfo>> partitions = Map.of(
+      "orders", List.of(partition("orders", 0), partition("orders", 1)),
+      "payments", List.of(partition("payments", 0)));
+
+    Map<TopicPartition, ListOffsetsResultInfo> maxTs = new HashMap<>();
+    Map<TopicPartition, ListOffsetsResultInfo> earliest = new HashMap<>();
+    Map<TopicPartition, ListOffsetsResultInfo> latest = new HashMap<>();
+    for (String topic : List.of("orders", "payments")) {
+      for (int p = 0; p < ("orders".equals(topic) ? 2 : 1); p++) {
+        TopicPartition tp = new TopicPartition(topic, p);
+        maxTs.put(tp, offset(90, NOW));
+        earliest.put(tp, offset(10, NOW - 60_000));
+        latest.put(tp, offset(100, -1));
+      }
+    }
+
+    Map<String, List<PartitionOffsets>> result =
+      KafkaClientServiceImpl.assembleOffsets(partitions, maxTs, earliest, latest);
+
+    assertEquals(2, result.size());
+    assertEquals(2, result.get("orders").size());
+    assertEquals(1, result.get("payments").size());
+
+    PartitionOffsets po = result.get("payments").get(0);
+    assertEquals("payments", po.topic());
+    // logEndOffset is always LATEST; the timestamp anchor comes from MAX_TIMESTAMP separately.
+    assertEquals(100, po.logEndOffset());
+    assertEquals(10, po.logStartOffset());
+    assertEquals(90, po.maxTimestampOffset());
+    assertEquals(NOW, po.logEndTimestamp());
+    assertEquals(3, po.replicaCount());
+    assertEquals(3, po.inSyncReplicaCount());
+  }
+
+  @Test
+  @DisplayName("a partition missing from listOffsets is skipped, its topic still returned")
+  void assembleOffsets_skipsMissingPartition() {
+    Map<String, List<PartitionInfo>> partitions = Map.of(
+      "orders", List.of(partition("orders", 0), partition("orders", 1)));
+
+    TopicPartition present = new TopicPartition("orders", 0);
+    Map<TopicPartition, ListOffsetsResultInfo> maxTs = Map.of(present, offset(90, NOW));
+    Map<TopicPartition, ListOffsetsResultInfo> earliest =
+      Map.of(present, offset(10, NOW - 60_000));
+    Map<TopicPartition, ListOffsetsResultInfo> latest = Map.of(present, offset(100, -1));
+
+    Map<String, List<PartitionOffsets>> result =
+      KafkaClientServiceImpl.assembleOffsets(partitions, maxTs, earliest, latest);
+
+    assertEquals(1, result.get("orders").size());
+    assertEquals(0, result.get("orders").get(0).partition());
+  }
+
+  @Test
+  @DisplayName("falls back to LATEST when MAX_TIMESTAMP is absent (pre-Kafka 3.0 broker)")
+  void assembleOffsets_maxTimestampFallback() {
+    Map<String, List<PartitionInfo>> partitions = Map.of("orders", List.of(partition("orders", 0)));
+    TopicPartition tp = new TopicPartition("orders", 0);
+
+    Map<String, List<PartitionOffsets>> result = KafkaClientServiceImpl.assembleOffsets(
+      partitions,
+      Map.of(), // MAX_TIMESTAMP leg failed for the whole cluster
+      Map.of(tp, offset(10, NOW - 60_000)),
+      Map.of(tp, offset(100, NOW)));
+
+    PartitionOffsets po = result.get("orders").get(0);
+    assertEquals(100, po.maxTimestampOffset());
+    assertEquals(NOW, po.logEndTimestamp());
+  }
+
+  @Test
+  @DisplayName("empty partition (earliest -1) normalises to start offset 0, no start timestamp")
+  void assembleOffsets_emptyPartition() {
+    Map<String, List<PartitionInfo>> partitions = Map.of("orders", List.of(partition("orders", 0)));
+    TopicPartition tp = new TopicPartition("orders", 0);
+
+    Map<String, List<PartitionOffsets>> result = KafkaClientServiceImpl.assembleOffsets(
+      partitions,
+      Map.of(tp, offset(-1, -1)),
+      Map.of(tp, offset(-1, -1)),
+      Map.of(tp, offset(0, -1)));
+
+    PartitionOffsets po = result.get("orders").get(0);
+    assertEquals(0, po.logStartOffset());
+    assertEquals(-1, po.logStartTimestamp());
+  }
+
+  @Test
+  @DisplayName("leaderless partition degrades instead of failing the whole batch")
+  void toPartitionInfo_nullLeaderAndReplicas() {
+    // Kafka reports a null leader for offline partitions; unguarded this threw inside the
+    // describeTopics mapper and would now fail every topic in the batch, not just this one.
+    TopicPartitionInfo offline = new TopicPartitionInfo(null, null, 3, null);
+
+    PartitionInfo info = assertDoesNotThrow(
+      () -> KafkaClientServiceImpl.toPartitionInfo("orders", offline));
+
+    assertEquals(3, info.partition());
+    assertEquals(-1, info.leader());
+    assertTrue(info.replicas().isEmpty());
+    assertTrue(info.inSyncReplicas().isEmpty());
+  }
+
+  @Test
+  @DisplayName("healthy partition keeps its leader and replica ids")
+  void toPartitionInfo_healthy() {
+    TopicPartitionInfo tpi =
+      new TopicPartitionInfo(List.of(node(1), node(2)), node(1), 0, List.of(node(1), node(2), node(3)));
+
+    PartitionInfo info = KafkaClientServiceImpl.toPartitionInfo("orders", tpi);
+
+    assertEquals(1, info.leader());
+    assertEquals(List.of(1, 2), info.inSyncReplicas());
+    assertEquals(List.of(1, 2, 3), info.replicas());
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorBatchingTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorBatchingTest.java
@@ -46,6 +46,8 @@ class MetricsCollectorBatchingTest {
     private final Map<String, List<String>> groupTopics;
     final List<Set<String>> batchCalls = new ArrayList<>();
     int perTopicCalls;
+    // Topics a group still has committed offsets for, but that no longer exist in the cluster.
+    Set<String> deletedTopics = Set.of();
 
     CountingKafka(Map<String, List<String>> groupTopics) {
       this.groupTopics = groupTopics;
@@ -85,7 +87,14 @@ class MetricsCollectorBatchingTest {
         Collectors.toMap(id -> id, id -> new ConsumerGroupState(id, State.STABLE))));
     }
 
-    @Override public Future<Set<String>> listTopics() { return Future.succeededFuture(Set.of()); }
+    // The collector filters the topic union against this before describing topics, so it has
+    // to report the topics the groups actually consume.
+    @Override public Future<Set<String>> listTopics() {
+      Set<String> live = groupTopics.values().stream().flatMap(List::stream)
+        .filter(topic -> !deletedTopics.contains(topic))
+        .collect(Collectors.toSet());
+      return Future.succeededFuture(live);
+    }
     @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return Future.succeededFuture(List.of()); }
     @Override public Future<String> describeCluster() { return Future.succeededFuture("cluster"); }
     @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return Future.succeededFuture(Map.of()); }
@@ -139,6 +148,24 @@ class MetricsCollectorBatchingTest {
         List<String> fetched = kafka.batchCalls.stream().flatMap(Set::stream).toList();
         assertEquals(10, fetched.size(), "every topic fetched exactly once per cycle");
         assertEquals(10, Set.copyOf(fetched).size());
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  @DisplayName("a deleted topic is filtered out instead of failing the whole batch")
+  void deletedTopicIsFilteredOut(Vertx vertx, VertxTestContext ctx) {
+    CountingKafka kafka = new CountingKafka(manyGroups());
+    // Committed offsets outlive a deleted topic until offsets.retention.minutes, so groups
+    // still report it. Without filtering, describeTopics (allTopicNames) fails the whole
+    // batch every cycle and stale-gauge cleanup stays frozen for as long as that lasts.
+    kafka.deletedTopics = Set.of("topic-3");
+
+    collector(vertx, kafka, new ChunkConfig(1, 0)).collectOnce().onComplete(ctx.succeeding(v ->
+      ctx.verify(() -> {
+        assertEquals(1, kafka.batchCalls.size());
+        assertEquals(9, kafka.batchCalls.get(0).size(), "deleted topic must not be described");
+        assertTrue(!kafka.batchCalls.get(0).contains("topic-3"));
         ctx.completeNow();
       })));
   }

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorBatchingTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorBatchingTest.java
@@ -1,0 +1,158 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.themoah.klag.kafka.ChunkConfig;
+import io.github.themoah.klag.kafka.KafkaClientService;
+import io.github.themoah.klag.metrics.hotpartition.HotPartitionConfig;
+import io.github.themoah.klag.metrics.timelag.TimeLagConfig;
+import io.github.themoah.klag.metrics.velocity.LagVelocityTracker;
+import io.github.themoah.klag.model.ConsumerGroupOffsets;
+import io.github.themoah.klag.model.ConsumerGroupOffsets.TopicPartitionKey;
+import io.github.themoah.klag.model.ConsumerGroupState;
+import io.github.themoah.klag.model.ConsumerGroupState.State;
+import io.github.themoah.klag.model.PartitionInfo;
+import io.github.themoah.klag.model.PartitionOffsets;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Regression guard for admin request volume.
+ *
+ * <p>Topic offsets used to be fetched one topic at a time, costing four admin requests per
+ * topic per cycle. These tests pin the batched behaviour: a cycle issues one batched fetch
+ * (or {@code chunkCount} of them when chunking is on) no matter how many groups and topics
+ * are involved, and never falls back to the per-topic call.
+ */
+@ExtendWith(VertxExtension.class)
+class MetricsCollectorBatchingTest {
+
+  /** Counts how the collector asks for topic offsets: batched vs per topic. */
+  private static class CountingKafka implements KafkaClientService {
+    private final Map<String, List<String>> groupTopics;
+    final List<Set<String>> batchCalls = new ArrayList<>();
+    int perTopicCalls;
+
+    CountingKafka(Map<String, List<String>> groupTopics) {
+      this.groupTopics = groupTopics;
+    }
+
+    @Override
+    public Future<Map<String, List<PartitionOffsets>>> getLogEndOffsets(Set<String> topics) {
+      batchCalls.add(Set.copyOf(topics));
+      Map<String, List<PartitionOffsets>> byTopic = new HashMap<>();
+      for (String topic : topics) {
+        byTopic.put(topic, List.of(new PartitionOffsets(topic, 0, 100, 0, 0, 100, 0, 3, 3)));
+      }
+      return Future.succeededFuture(byTopic);
+    }
+
+    @Override
+    public Future<List<PartitionOffsets>> getLogEndOffsets(String topic) {
+      perTopicCalls++;
+      return Future.succeededFuture(List.of(new PartitionOffsets(topic, 0, 100, 0, 0, 100, 0, 3, 3)));
+    }
+
+    @Override
+    public Future<ConsumerGroupOffsets> getConsumerGroupOffsets(String groupId) {
+      Map<TopicPartitionKey, Long> offsets = groupTopics.get(groupId).stream()
+        .collect(Collectors.toMap(topic -> new TopicPartitionKey(topic, 0), topic -> 40L));
+      return Future.succeededFuture(new ConsumerGroupOffsets(groupId, offsets));
+    }
+
+    @Override
+    public Future<Set<String>> listConsumerGroups() {
+      return Future.succeededFuture(groupTopics.keySet());
+    }
+
+    @Override
+    public Future<Map<String, ConsumerGroupState>> describeConsumerGroups(Set<String> groupIds) {
+      return Future.succeededFuture(groupIds.stream().collect(
+        Collectors.toMap(id -> id, id -> new ConsumerGroupState(id, State.STABLE))));
+    }
+
+    @Override public Future<Set<String>> listTopics() { return Future.succeededFuture(Set.of()); }
+    @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return Future.succeededFuture(List.of()); }
+    @Override public Future<String> describeCluster() { return Future.succeededFuture("cluster"); }
+    @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return Future.succeededFuture(Map.of()); }
+    @Override public Future<Void> close() { return Future.succeededFuture(); }
+  }
+
+  /** 20 groups, each on 5 topics drawn from a shared pool of 10 distinct topics. */
+  private static Map<String, List<String>> manyGroups() {
+    return IntStream.range(0, 20).boxed().collect(Collectors.toMap(
+      g -> "group-" + g,
+      g -> IntStream.range(0, 5).mapToObj(t -> "topic-" + ((g + t) % 10)).collect(Collectors.toList())));
+  }
+
+  private MetricsCollector collector(Vertx vertx, KafkaClientService kafka, ChunkConfig chunks) {
+    return new MetricsCollector(vertx, kafka,
+      new MicrometerReporter(new SimpleMeterRegistry()), 60_000, "*", "",
+      new LagVelocityTracker(),
+      new HotPartitionConfig(false, 2.0, 3, 3, 20),
+      new TimeLagConfig(true, 100, 60, 180_000),
+      chunks);
+  }
+
+  @Test
+  @DisplayName("one cycle over 20 groups x 10 topics issues a single batched offset fetch")
+  void singleBatchPerCycle(Vertx vertx, VertxTestContext ctx) {
+    CountingKafka kafka = new CountingKafka(manyGroups());
+
+    collector(vertx, kafka, new ChunkConfig(1, 0)).collectOnce().onComplete(ctx.succeeding(v ->
+      ctx.verify(() -> {
+        assertEquals(1, kafka.batchCalls.size(), "expected exactly one batched fetch per cycle");
+        // The union of all groups' topics, deduped — not 20 groups x 5 topics.
+        assertEquals(10, kafka.batchCalls.get(0).size());
+        assertEquals(0, kafka.perTopicCalls, "per-topic fetch must not be used");
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  @DisplayName("chunking batches per chunk and never refetches a topic within a cycle")
+  void chunkedStillBatches(Vertx vertx, VertxTestContext ctx) {
+    CountingKafka kafka = new CountingKafka(manyGroups());
+
+    // 2 group chunks x 2 topic chunks is the ceiling; group chunks share topics, and the
+    // per-cycle cache means the later chunk only fetches what is still unresolved.
+    collector(vertx, kafka, new ChunkConfig(2, 0)).collectOnce().onComplete(ctx.succeeding(v ->
+      ctx.verify(() -> {
+        assertTrue(kafka.batchCalls.size() <= 4,
+          "expected at most chunkCount^2 batched fetches, got " + kafka.batchCalls.size());
+        assertEquals(0, kafka.perTopicCalls, "per-topic fetch must not be used");
+
+        List<String> fetched = kafka.batchCalls.stream().flatMap(Set::stream).toList();
+        assertEquals(10, fetched.size(), "every topic fetched exactly once per cycle");
+        assertEquals(10, Set.copyOf(fetched).size());
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  @DisplayName("group fan-out is bounded into waves, all groups still collected")
+  void groupFanOutIsBounded(Vertx vertx, VertxTestContext ctx) {
+    CountingKafka kafka = new CountingKafka(manyGroups());
+
+    collector(vertx, kafka, new ChunkConfig(1, 0)).collectOnce().onComplete(ctx.succeeding(v ->
+      ctx.verify(() -> {
+        // Bounding must not drop groups: every topic any group consumes is still fetched.
+        assertEquals(10, kafka.batchCalls.get(0).size());
+        ctx.completeNow();
+      })));
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorChunkingTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorChunkingTest.java
@@ -49,6 +49,7 @@ class MetricsCollectorChunkingTest {
     final Map<String, Integer> topicPartitions;
     volatile Map<String, State> states = new HashMap<>();
     volatile Set<String> failingGroups = Set.of();
+    volatile Set<String> failingOffsetGroups = Set.of();
 
     ChunkedFakeKafka(Map<String, String> groupToTopic, Map<String, Integer> topicPartitions) {
       this.groupToTopic = groupToTopic;
@@ -68,6 +69,9 @@ class MetricsCollectorChunkingTest {
     }
 
     @Override public Future<ConsumerGroupOffsets> getConsumerGroupOffsets(String groupId) {
+      if (failingOffsetGroups.contains(groupId)) {
+        return Future.failedFuture("injected listConsumerGroupOffsets failure for " + groupId);
+      }
       String topic = groupToTopic.get(groupId);
       Map<TopicPartitionKey, Long> offsets = new HashMap<>();
       for (int p = 0; p < topicPartitions.get(topic); p++) {
@@ -199,6 +203,41 @@ class MetricsCollectorChunkingTest {
           .tag("consumer_group", "group-a").gauge();
         assertNotNull(lagSumA, "group-a gauges must not be deleted on partial cycles");
         assertEquals(100.0, lagSumA.value(), "group-a keeps its last good value (cycle 1)");
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  void skippedGroupOffsetsDoNotDeleteThatGroupsGauges(Vertx vertx, VertxTestContext ctx) {
+    // Non-chunked path: one group's listConsumerGroupOffsets fails (coordinator hiccup,
+    // ACL gap, group deleted mid-cycle). It is skipped, so its keys are absent from the
+    // cycle accumulators — the retainAll cleanups must not run against that partial set.
+    ChunkedFakeKafka kafka = new ChunkedFakeKafka(TWO_GROUPS,
+      Map.of("topic-a", 1, "topic-b", 1));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MetricsCollector collector = new MetricsCollector(vertx, kafka,
+      new MicrometerReporter(registry), 60_000, "*", "",
+      new LagVelocityTracker(),
+      new HotPartitionConfig(false, 2.0, 3, 3, 20),
+      new TimeLagConfig(true, 100, 60, 180_000),
+      new ChunkConfig(1, 0));
+
+    collector.collectOnce()
+      .compose(v -> {
+        kafka.failingOffsetGroups = Set.of("group-a");
+        return collector.collectOnce(); // cycle 2: group-a's offsets fail
+      })
+      .compose(v -> collector.collectOnce()) // cycle 3: still failing
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        Gauge lagSumA = registry.find("klag.consumer.lag.sum")
+          .tag("consumer_group", "group-a").gauge();
+        assertNotNull(lagSumA, "group-a gauges must not be deleted when its offsets fetch fails");
+        assertEquals(50.0, lagSumA.value(), "group-a keeps its last good value (cycle 1)");
+
+        Gauge lagSumB = registry.find("klag.consumer.lag.sum")
+          .tag("consumer_group", "group-b").gauge();
+        assertNotNull(lagSumB, "group-b lag gauge must exist");
+        assertEquals(150.0, lagSumB.value(), "group-b must still be collected");
         ctx.completeNow();
       })));
   }

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorChunkingTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorChunkingTest.java
@@ -101,7 +101,10 @@ class MetricsCollectorChunkingTest {
       return Future.succeededFuture(result);
     }
 
-    @Override public Future<Set<String>> listTopics() { return Future.succeededFuture(Set.of()); }
+    // The collector filters the topic union against this before describing topics.
+    @Override public Future<Set<String>> listTopics() {
+      return Future.succeededFuture(Set.copyOf(topicPartitions.keySet()));
+    }
     @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return Future.succeededFuture(List.of()); }
     @Override public Future<String> describeCluster() { return Future.succeededFuture("cluster"); }
     @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return Future.succeededFuture(Map.of()); }

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorSnapshotTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorSnapshotTest.java
@@ -30,28 +30,48 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(VertxExtension.class)
 class MetricsCollectorSnapshotTest {
 
-  /** Minimal fake exposing one group consuming one topic/partition with lag. */
+  /** Minimal fake exposing groups consuming one topic/partition with lag. */
   private static class FakeKafka implements KafkaClientService {
+    private final Set<String> groups;
+    private final Set<String> failingGroups;
+
+    FakeKafka() {
+      this(Set.of("payments"), Set.of());
+    }
+
+    FakeKafka(Set<String> groups, Set<String> failingGroups) {
+      this.groups = groups;
+      this.failingGroups = failingGroups;
+    }
+
     @Override public Future<Set<String>> listTopics() { return Future.succeededFuture(Set.of("orders")); }
     @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return Future.succeededFuture(List.of()); }
     @Override public Future<List<PartitionOffsets>> getLogEndOffsets(String topic) {
       return Future.succeededFuture(List.of(new PartitionOffsets(topic, 0, 100, 0, 0, 100, 0, 3, 3)));
     }
     @Override public Future<ConsumerGroupOffsets> getConsumerGroupOffsets(String groupId) {
+      if (failingGroups.contains(groupId)) {
+        return Future.failedFuture("injected offset failure for " + groupId);
+      }
       return Future.succeededFuture(new ConsumerGroupOffsets(groupId,
         Map.of(new TopicPartitionKey("orders", 0), 40L)));
     }
     @Override public Future<String> describeCluster() { return Future.succeededFuture("cluster"); }
-    @Override public Future<Set<String>> listConsumerGroups() { return Future.succeededFuture(Set.of("payments")); }
+    @Override public Future<Set<String>> listConsumerGroups() { return Future.succeededFuture(groups); }
     @Override public Future<Map<String, ConsumerGroupState>> describeConsumerGroups(Set<String> groupIds) {
-      return Future.succeededFuture(Map.of("payments", new ConsumerGroupState("payments", State.STABLE)));
+      return Future.succeededFuture(groupIds.stream().collect(
+        java.util.stream.Collectors.toMap(id -> id, id -> new ConsumerGroupState(id, State.STABLE))));
     }
     @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return Future.succeededFuture(Map.of()); }
     @Override public Future<Void> close() { return Future.succeededFuture(); }
   }
 
   private MetricsCollector collector(Vertx vertx, SnapshotStore store) {
-    MetricsCollector c = new MetricsCollector(vertx, new FakeKafka(),
+    return collector(vertx, store, new FakeKafka());
+  }
+
+  private MetricsCollector collector(Vertx vertx, SnapshotStore store, KafkaClientService kafka) {
+    MetricsCollector c = new MetricsCollector(vertx, kafka,
       new MicrometerReporter(new SimpleMeterRegistry()), 60_000, "*");
     c.setSnapshotStore(store);
     return c;
@@ -66,6 +86,38 @@ class MetricsCollectorSnapshotTest {
         assertEquals(1, snap.groups().size());
         assertEquals("payments", snap.groups().get(0).consumerGroup());
         assertEquals(60, snap.groups().get(0).totalLag());
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  void partialCycleStillPublishesSurvivingGroups(Vertx vertx, VertxTestContext ctx) {
+    // One permanently failing group (ACL gap, wedged coordinator) must not freeze the MCP
+    // view of every other group while /metrics keeps updating.
+    SnapshotStore store = new SnapshotStore();
+    FakeKafka kafka = new FakeKafka(Set.of("payments", "broken"), Set.of("broken"));
+
+    collector(vertx, store, kafka).collectOnce()
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        MetricsSnapshot snap = store.latest().orElseThrow();
+        assertEquals(1, snap.groups().size());
+        assertEquals("payments", snap.groups().get(0).consumerGroup());
+        ctx.completeNow();
+      })));
+  }
+
+  @Test
+  void totalFailureKeepsPreviousSnapshotInsteadOfWipingIt(Vertx vertx, VertxTestContext ctx) {
+    SnapshotStore store = new SnapshotStore();
+    FakeKafka allBroken = new FakeKafka(Set.of("payments"), Set.of("payments"));
+
+    collector(vertx, store).collectOnce()
+      .compose(v -> collector(vertx, store, allBroken).collectOnce())
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        // Nothing was collected at all: a wiped agent view is worse than a stale one.
+        MetricsSnapshot snap = store.latest().orElseThrow();
+        assertEquals(1, snap.groups().size());
+        assertEquals("payments", snap.groups().get(0).consumerGroup());
         ctx.completeNow();
       })));
   }

--- a/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorStartupTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/MetricsCollectorStartupTest.java
@@ -1,0 +1,93 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.themoah.klag.kafka.KafkaClientService;
+import io.github.themoah.klag.metrics.snapshot.SnapshotStore;
+import io.github.themoah.klag.model.ConsumerGroupOffsets;
+import io.github.themoah.klag.model.ConsumerGroupState;
+import io.github.themoah.klag.model.MetricsSnapshot;
+import io.github.themoah.klag.model.PartitionInfo;
+import io.github.themoah.klag.model.PartitionOffsets;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Startup and empty-cycle behaviour of the collector: a broker that is unreachable at boot
+ * must degrade rather than fail startup (which exits the process), and a cycle that sees no
+ * groups must still run cycle-end cleanup and refresh the MCP snapshot.
+ */
+@ExtendWith(VertxExtension.class)
+class MetricsCollectorStartupTest {
+
+  /** Kafka that answers nothing: every admin call fails. */
+  private static class DeadKafka implements KafkaClientService {
+    private static <T> Future<T> down() {
+      return Future.failedFuture(new RuntimeException("broker down"));
+    }
+
+    @Override public Future<Set<String>> listTopics() { return down(); }
+    @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return down(); }
+    @Override public Future<List<PartitionOffsets>> getLogEndOffsets(String topic) { return down(); }
+    @Override public Future<ConsumerGroupOffsets> getConsumerGroupOffsets(String groupId) { return down(); }
+    @Override public Future<String> describeCluster() { return down(); }
+    @Override public Future<Set<String>> listConsumerGroups() { return down(); }
+    @Override public Future<Map<String, ConsumerGroupState>> describeConsumerGroups(Set<String> groupIds) { return down(); }
+    @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return down(); }
+    @Override public Future<Void> close() { return Future.succeededFuture(); }
+  }
+
+  /** Healthy Kafka with no consumer groups at all. */
+  private static class EmptyKafka implements KafkaClientService {
+    @Override public Future<Set<String>> listTopics() { return Future.succeededFuture(Set.of()); }
+    @Override public Future<List<PartitionInfo>> listPartitions(String topic) { return Future.succeededFuture(List.of()); }
+    @Override public Future<List<PartitionOffsets>> getLogEndOffsets(String topic) { return Future.succeededFuture(List.of()); }
+    @Override public Future<ConsumerGroupOffsets> getConsumerGroupOffsets(String groupId) {
+      return Future.succeededFuture(new ConsumerGroupOffsets(groupId, Map.of()));
+    }
+    @Override public Future<String> describeCluster() { return Future.succeededFuture("cluster"); }
+    @Override public Future<Set<String>> listConsumerGroups() { return Future.succeededFuture(Set.of()); }
+    @Override public Future<Map<String, ConsumerGroupState>> describeConsumerGroups(Set<String> groupIds) {
+      return Future.succeededFuture(Map.of());
+    }
+    @Override public Future<Map<String, Long>> getTopicRetentionMs(Set<String> topics) { return Future.succeededFuture(Map.of()); }
+    @Override public Future<Void> close() { return Future.succeededFuture(); }
+  }
+
+  private static MetricsCollector collector(Vertx vertx, KafkaClientService kafka) {
+    return new MetricsCollector(vertx, kafka,
+      new MicrometerReporter(new SimpleMeterRegistry()), 60_000, "*");
+  }
+
+  @Test
+  void startSucceedsWhenKafkaIsDown(Vertx vertx, VertxTestContext ctx) {
+    MetricsCollector collector = collector(vertx, new DeadKafka());
+    collector.start()
+      .onComplete(ctx.succeeding(v -> collector.stop()
+        .onComplete(ctx.succeedingThenComplete())));
+  }
+
+  @Test
+  void emptyCycleRefreshesSnapshot(Vertx vertx, VertxTestContext ctx) {
+    SnapshotStore store = new SnapshotStore();
+    MetricsCollector collector = collector(vertx, new EmptyKafka());
+    collector.setSnapshotStore(store);
+
+    collector.collectOnce()
+      .onComplete(ctx.succeeding(v -> ctx.verify(() -> {
+        MetricsSnapshot snap = store.latest().orElseThrow();
+        assertTrue(snap.groups().isEmpty());
+        assertEquals(0, snap.hotPartitionsByThroughput().size());
+        ctx.completeNow();
+      })));
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionDetectorTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionDetectorTest.java
@@ -1,0 +1,89 @@
+package io.github.themoah.klag.metrics.hotpartition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.themoah.klag.model.ConsumerGroupLag;
+import io.github.themoah.klag.model.ConsumerGroupLag.PartitionLag;
+import io.github.themoah.klag.model.HotPartitionLag;
+import io.github.themoah.klag.model.HotPartitionThroughput;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Kafka topic names may legally contain ':', which is also the separator of the internal
+ * partition-history key. Detection must never parse that key back into topic/partition.
+ */
+class HotPartitionDetectorTest {
+
+  private static final String TOPIC = "app:events";
+
+  // sigma 1.0: with only 4 partitions the population z-score is capped at 1.5, so the
+  // default 2.0 could never flag an outlier in a fixture this small.
+  private static final HotPartitionConfig CONFIG =
+      new HotPartitionConfig(true, 1.0, 3, 2, 20);
+
+  private static List<ConsumerGroupLag> lagData(long... logEndOffsets) {
+    List<PartitionLag> partitions = new ArrayList<>();
+    for (int p = 0; p < logEndOffsets.length; p++) {
+      partitions.add(PartitionLag.of(TOPIC, p, logEndOffsets[p], 0, 0, 0, 0));
+    }
+    return List.of(ConsumerGroupLag.fromPartitions("group", partitions));
+  }
+
+  @Test
+  void colonInTopicName_throughputDetectionStillWorks() throws InterruptedException {
+    HotPartitionDetector detector = new HotPartitionDetector(CONFIG);
+
+    Set<String> firstKeys = detector.recordThroughputSnapshots(lagData(0, 0, 0, 0));
+    assertEquals(4, firstKeys.size());
+
+    // Distinct timestamps: the throughput regression needs a non-zero time spread.
+    Thread.sleep(20);
+    detector.recordThroughputSnapshots(lagData(10, 10, 10, 1000));
+
+    List<HotPartitionThroughput> hot = detector.detectHotPartitionsByThroughput();
+
+    assertEquals(1, hot.size());
+    assertEquals(TOPIC, hot.get(0).topic());
+    assertEquals(3, hot.get(0).partition());
+  }
+
+  @Test
+  void colonInTopicName_lagDetectionStillWorks() {
+    HotPartitionDetector detector = new HotPartitionDetector(CONFIG);
+
+    // Partition 3 is far behind; partitions 0-2 are caught up.
+    List<PartitionLag> partitions = List.of(
+      PartitionLag.of(TOPIC, 0, 100, 0, 0, 0, 100),
+      PartitionLag.of(TOPIC, 1, 100, 0, 0, 0, 100),
+      PartitionLag.of(TOPIC, 2, 100, 0, 0, 0, 100),
+      PartitionLag.of(TOPIC, 3, 100, 0, 0, 0, 0));
+
+    List<HotPartitionLag> hot = detector.detectHotPartitionsByLag(
+      List.of(ConsumerGroupLag.fromPartitions("group", partitions)));
+
+    assertEquals(1, hot.size());
+    assertEquals(TOPIC, hot.get(0).topic());
+    assertEquals(3, hot.get(0).partition());
+  }
+
+  @Test
+  void cleanupUsesTheKeysDetectionReturns() throws InterruptedException {
+    HotPartitionDetector detector = new HotPartitionDetector(CONFIG);
+
+    Set<String> activeKeys = detector.recordThroughputSnapshots(lagData(0, 0, 0, 0));
+    detector.cleanupStalePartitions(activeKeys);
+    assertEquals(4, activeKeys.size());
+
+    Thread.sleep(20);
+    detector.recordThroughputSnapshots(lagData(10, 10, 10, 1000));
+
+    // Detection needs 2 samples per partition. If cleanup had dropped the first sample
+    // (mismatched key format), only one would remain and nothing could be flagged.
+    List<HotPartitionThroughput> hot = detector.detectHotPartitionsByThroughput();
+    assertEquals(1, hot.size());
+    assertEquals(3, hot.get(0).partition());
+  }
+}

--- a/src/test/java/io/github/themoah/klag/model/ConsumerGroupStateTest.java
+++ b/src/test/java/io/github/themoah/klag/model/ConsumerGroupStateTest.java
@@ -1,0 +1,35 @@
+package io.github.themoah.klag.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.themoah.klag.model.ConsumerGroupState.State;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the name-based mapping in {@link State#fromKafkaState(String)}: it exists so klag
+ * never references org.apache.kafka.common.ConsumerGroupState, which kafka-clients 4.x
+ * deprecated for removal. The mapping is only safe while the names line up.
+ */
+class ConsumerGroupStateTest {
+
+  @Test
+  void mapsEveryKafkaStateName() {
+    // Names as emitted by kafka-clients' group-state enums (both the deprecated
+    // ConsumerGroupState and its GroupState replacement use these constants).
+    assertEquals(State.PREPARING_REBALANCE, State.fromKafkaState("PREPARING_REBALANCE"));
+    assertEquals(State.COMPLETING_REBALANCE, State.fromKafkaState("COMPLETING_REBALANCE"));
+    assertEquals(State.STABLE, State.fromKafkaState("STABLE"));
+    assertEquals(State.DEAD, State.fromKafkaState("DEAD"));
+    assertEquals(State.EMPTY, State.fromKafkaState("EMPTY"));
+    assertEquals(State.UNKNOWN, State.fromKafkaState("UNKNOWN"));
+  }
+
+  @Test
+  void unrecognisedAndNullNamesBecomeUnknown() {
+    assertEquals(State.UNKNOWN, State.fromKafkaState(null));
+    // New consumer protocol states klag does not model must degrade, not throw.
+    assertEquals(State.UNKNOWN, State.fromKafkaState("ASSIGNING"));
+    assertEquals(State.UNKNOWN, State.fromKafkaState("RECONCILING"));
+    assertEquals(State.UNKNOWN, State.fromKafkaState(""));
+  }
+}

--- a/src/test/java/io/github/themoah/klag/model/ConsumerGroupStateTest.java
+++ b/src/test/java/io/github/themoah/klag/model/ConsumerGroupStateTest.java
@@ -18,6 +18,10 @@ class ConsumerGroupStateTest {
     // ConsumerGroupState and its GroupState replacement use these constants).
     assertEquals(State.PREPARING_REBALANCE, State.fromKafkaState("PREPARING_REBALANCE"));
     assertEquals(State.COMPLETING_REBALANCE, State.fromKafkaState("COMPLETING_REBALANCE"));
+    // KIP-848 new consumer protocol: these replace the two rebalance states above and must
+    // map to their own tags, otherwise rebalance alerting goes silent on upgraded groups.
+    assertEquals(State.ASSIGNING, State.fromKafkaState("ASSIGNING"));
+    assertEquals(State.RECONCILING, State.fromKafkaState("RECONCILING"));
     assertEquals(State.STABLE, State.fromKafkaState("STABLE"));
     assertEquals(State.DEAD, State.fromKafkaState("DEAD"));
     assertEquals(State.EMPTY, State.fromKafkaState("EMPTY"));
@@ -27,9 +31,8 @@ class ConsumerGroupStateTest {
   @Test
   void unrecognisedAndNullNamesBecomeUnknown() {
     assertEquals(State.UNKNOWN, State.fromKafkaState(null));
-    // New consumer protocol states klag does not model must degrade, not throw.
-    assertEquals(State.UNKNOWN, State.fromKafkaState("ASSIGNING"));
-    assertEquals(State.UNKNOWN, State.fromKafkaState("RECONCILING"));
+    // Any future state klag does not model must degrade, not throw.
+    assertEquals(State.UNKNOWN, State.fromKafkaState("SOME_FUTURE_STATE"));
     assertEquals(State.UNKNOWN, State.fromKafkaState(""));
   }
 }

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -34,7 +34,7 @@ stack.
 | **Lag velocity** | Know if lag is growing or shrinking, to catch problems before they escalate. |
 | **Time-based lag estimation** | See lag in seconds/minutes, beyond raw message counts. |
 | **Hot partition detection** | Find partitions with uneven load causing bottlenecks. |
-| **Consumer group state tracking** | Alert on `preparing_rebalance`, `completing_rebalance`, `dead`, or `empty` states. |
+| **Consumer group state tracking** | Alert on `preparing_rebalance`, `completing_rebalance` (`assigning`/`reconciling` on KIP-848 groups), `dead`, or `empty` states. |
 | **Request batching** | Safely monitor large clusters without overwhelming brokers. |
 | **Stale group cleanup** | Automatically stops reporting deleted/inactive groups. |
 | **Data loss prevention** | Catch the case where lag exceeds retention and data is lost. |

--- a/website/src/content/docs/guides/consumer-monitoring-mistakes.md
+++ b/website/src/content/docs/guides/consumer-monitoring-mistakes.md
@@ -32,9 +32,11 @@ A group can go `empty` (all consumers gone) or thrash through
 watch lag, a group that reaches `dead` can stay quiet until the backlog is huge.
 
 **Instead:** select `klag_consumer_group_state` by its lowercase `state` tag. The real
-values are `stable`, `preparing_rebalance`, `completing_rebalance`, `empty`, `dead`, and
-`unknown`; there is no generic `rebalancing` state. The gauge value is a state-change
-count, not an encoded state number.
+values are `stable`, `preparing_rebalance`, `completing_rebalance`, `assigning`,
+`reconciling`, `empty`, `dead`, and `unknown`; there is no generic `rebalancing` state.
+Groups on the KIP-848 consumer protocol report `assigning`/`reconciling` instead of the
+classic rebalance pair, so rebalance alerts must match all four. The gauge value is a
+state-change count, not an encoded state number.
 
 For example, detect an empty or dead group by label presence:
 

--- a/website/src/content/docs/guides/troubleshooting.md
+++ b/website/src/content/docs/guides/troubleshooting.md
@@ -68,6 +68,52 @@ METRICS_GROUP_EXCLUDE=
 Then add patterns back one at a time. Excludes run after includes. See
 [Group Filtering](/configuration/group-filtering/).
 
+## Old series never disappear from `/metrics`
+
+**Likely cause:** Stale-gauge cleanup only runs after a **complete** collection cycle. If
+one group fails every cycle — a missing group `DESCRIBE` ACL, a wedged coordinator — the
+cycle is permanently partial and cleanup never runs, so series for deleted groups, topics,
+and rotated consumer members linger indefinitely. The log carries
+`Failed to collect lag for group <id> (skipped this cycle)` and
+`Collection cycle was partial` every interval, naming the group.
+
+This is deliberate: cleaning up against an incomplete key set would delete live series.
+Stale values beat deleted ones — but the freeze lasts as long as the failure does.
+
+**Fix:** Grant the group the [required ACLs](/kafka/acl-permissions/), or drop it with
+`METRICS_GROUP_EXCLUDE`. Cleanup resumes on the next complete cycle. The MCP snapshot is
+unaffected: it keeps publishing the groups that did succeed.
+
+## A deleted topic's series stay, or a live topic's series disappear
+
+Klag filters each cycle's topic set against the cluster's topic list before requesting
+metadata, because the Kafka admin call fails as a whole if any topic in the batch is
+unknown — and a group's committed offsets outlive a deleted topic until
+`offsets.retention.minutes` (7 days by default). Without the filter, one deleted topic
+would keep every cycle partial, and cleanup frozen, for that long.
+
+The cost is an ACL asymmetry: `listTopics` only returns topics the principal can see. If
+Klag can read a group's committed offsets for a topic it cannot describe, that topic looks
+deleted and its series are retired within 1–2 cycles. The log records
+`Skipping N topic(s) absent from the cluster topic list`.
+
+**Fix:** Grant topic `DESCRIBE` matching the group access you granted — see
+[ACL Permissions](/kafka/acl-permissions/). Asymmetric grants are the only case where a
+live topic goes missing this way.
+
+## Collection cycles overrun the interval on large clusters
+
+**Likely cause:** Each cycle issues one batched `listOffsets` per request type covering
+every partition in scope. The Kafka AdminClient splits that per leader broker, and the
+timestamp lookups it performs scale with **partitions per broker**, so a cluster with few
+brokers and many partitions can approach `KAFKA_REQUEST_TIMEOUT_MS` (default 30000). The
+log shows `Skipping collection tick: previous cycle still running`.
+
+**Fix:** Set `KAFKA_CHUNK_COUNT` above 1. Chunking splits the work into partition-weighted
+batches processed sequentially, with `KAFKA_CHUNK_DELAY_MS` between them. Raising
+`METRICS_INTERVAL_MS` or `KAFKA_REQUEST_TIMEOUT_MS` also helps. See the
+[Configuration Reference](/configuration/reference/#kafka).
+
 ## Velocity or time-lag metrics are missing at first
 
 **Likely cause:** Lag velocity needs three collection samples. The time-lag fallback

--- a/website/src/content/docs/guides/troubleshooting.md
+++ b/website/src/content/docs/guides/troubleshooting.md
@@ -23,6 +23,11 @@ defaults `metrics.reporter` to `prometheus`. See
 no group remains after filtering. The collector starts one cycle immediately; velocity
 and some derived metrics still need more samples.
 
+If Kafka is unreachable at startup, Klag **stays running (degraded)** instead of
+exiting — `/readyz` returns `503` until connectivity is restored and a cycle succeeds.
+This is intentional: the process tolerates a broker outage at boot like the health
+monitor, so a transient Kafka blip does not crash-loop the pod.
+
 **Fix:** Check the logs for a completed collection or Kafka errors. Verify
 `KAFKA_BOOTSTRAP_SERVERS`, the [required ACLs](/kafka/acl-permissions/), and the
 [group filters](/configuration/group-filtering/). Wait for a successful cycle. If the
@@ -80,8 +85,11 @@ handle the added polling load. See [Lag Velocity](/metrics/lag-velocity/) and
 
 - `401`: `MCP_AUTH_TOKEN` is set and the Bearer token is missing or wrong.
 - `405`: The client sent `GET`; Klag accepts JSON-RPC 2.0 over `POST`.
-- Snapshot not ready: metrics collection is disabled, the first cycle has not
-  succeeded, or filters leave no groups to collect.
+- Snapshot not ready: metrics collection is disabled or the first cycle has not
+  succeeded, so no snapshot exists yet.
+- Snapshot empty (`groupCount: 0`): reports ran, but the group filters left no
+  groups to collect. Each cycle publishes a refreshed empty snapshot rather than
+  returning stale data from an earlier run.
 
 **Fix:** Send `Authorization: Bearer <token>`, use a Streamable HTTP MCP client that
 posts JSON-RPC requests, and select a reporter with `METRICS_REPORTER`. Then resolve

--- a/website/src/content/docs/metrics/overview.md
+++ b/website/src/content/docs/metrics/overview.md
@@ -25,8 +25,16 @@ Broker/topic signals such as throughput and ISR do not have a `consumer_group` t
 ### Consumer-group state
 
 `klag.consumer.group.state` has `consumer_group` and a lowercase `state` tag. The
-possible values are `stable`, `preparing_rebalance`, `completing_rebalance`, `empty`,
-`dead`, and `unknown`. There is no generic `rebalancing` value.
+possible values are `stable`, `preparing_rebalance`, `completing_rebalance`, `assigning`,
+`reconciling`, `empty`, `dead`, and `unknown`. There is no generic `rebalancing` value.
+
+Groups on the KIP-848 consumer protocol (Kafka 4.0+) report `assigning` and `reconciling`
+in place of `preparing_rebalance` and `completing_rebalance`. Alerts that name only the
+classic pair go silent on upgraded groups — match all four:
+
+```promql
+klag_consumer_group_state{state=~"preparing_rebalance|completing_rebalance|assigning|reconciling"}
+```
 
 The gauge value is a consecutive state-change count, **not** an encoded state or a
 lifetime cumulative total. It starts at `0`, rises while the state changes on


### PR DESCRIPTION
## Summary by Sourcery

Harden metrics collection around startup, empty cycles, and hot-partition throughput, and bump the project/chart versions.

Bug Fixes:
- Prevent metrics collector startup from failing when Kafka is unreachable by degrading the first collection cycle instead of exiting.
- Ensure an empty collection cycle still performs full cleanup and refreshes the metrics control-plane snapshot to avoid stale state.
- Fix hot-partition throughput detection so topic names containing ':' no longer break collection cycles by avoiding key-string parsing.

Enhancements:
- Expose partition throughput metrics grouped by topic from the partition throughput tracker, using the retained topic/partition metadata instead of parsing compound keys.

Build:
- Bump application version from 0.2.12 to 0.2.13 in the Gradle build.
- Bump Helm chart version from 0.3.7 to 0.3.8 and align appVersion to 0.2.13 with updated release notes.

Tests:
- Add startup and empty-cycle tests for the metrics collector to verify degraded startup and snapshot refresh behaviour when Kafka is down or has no consumer groups.
- Add hot-partition detector tests covering colon-containing topic names and cleanup behaviour to ensure throughput and lag detection remain correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batched Kafka offset retrieval with configurable concurrency limits.
  * Enabled virtual threads by default in the Helm chart.
  * Added support for leaderless partitions and topic names containing colons.
* **Bug Fixes**
  * Improved startup recovery when Kafka is unavailable.
  * Improved empty snapshot refreshes and consumer-group failure handling.
  * Improved partition metadata and offset fallback handling.
* **Documentation**
  * Updated configuration, troubleshooting, and release documentation.
* **Tests**
  * Added coverage for batching, startup recovery, snapshots, special topic names, and partition edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->