### PR TITLE
adding support for easier onboarding with ai agent (claude, codex, etc)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://code.claude.com/schemas/marketplace.json",
+  "name": "klag",
+  "description": "The Klag Kafka consumer lag exporter: install it, connect its MCP endpoint, and triage consumer lag from your agent.",
+  "owner": {
+    "name": "themoah",
+    "url": "https://klag.dev"
+  },
+  "plugins": [
+    {
+      "name": "klag",
+      "source": "./plugin",
+      "description": "Install, connect and diagnose Klag — the Kafka consumer lag exporter."
+    }
+  ]
+}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       helm: ${{ steps.filter.outputs.helm }}
+      plugin: ${{ steps.filter.outputs.plugin }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,6 +33,21 @@ jobs:
               - 'scripts/test-helm-chart.sh'
               - 'scripts/check-version-consistency.sh'
               - 'build.gradle.kts'
+            plugin:
+              - '.claude-plugin/**'
+              - 'plugin/**'
+              - 'scripts/check-plugin.sh'
+
+  test-plugin:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.plugin == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Claude Code plugin manifests
+        run: ./scripts/check-plugin.sh
 
   test-helm-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,9 +42,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.plugin == 'true'
+    # The job runs a script from the checked-out ref: read-only token, no persisted credentials.
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate Claude Code plugin manifests
         run: ./scripts/check-plugin.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,21 @@ fixed by ACL or `METRICS_GROUP_EXCLUDE`. The snapshot is exempt so agents don't 
 hours-old data while `/metrics` stays current; an *empty* snapshot is not published, since
 wiping the agent view is worse than a stale one.
 
+## Agent onboarding plugin
+
+The repo doubles as a Claude Code marketplace: `.claude-plugin/marketplace.json` (root) points at
+`./plugin`, which holds `plugin/.claude-plugin/plugin.json`, `plugin/commands/{install,connect,diagnose}.md`
+(→ `/klag:install` etc.) and `plugin/skills/klag/`. Users get it with
+`/plugin marketplace add themoah/klag` + `/plugin install klag@klag`.
+
+The `source: "./plugin"` subdir is deliberate: with `"./"` the plugin root is the repo root, so an
+install copies the entire tree — a local directory install measured 620 MB (`website/node_modules`,
+`build/`, even `.env`), and a GitHub install would clone every tracked file. With `./plugin` the
+installed payload is 36 KB. Keep the skill thin — it fetches
+`klag.dev/llms.txt` rather than duplicating the config reference, so it cannot drift.
+`scripts/check-plugin.sh` pins manifest shape and runs in CI. User-facing page:
+`website/src/content/docs/ai/agent-setup.mdx` (`klag.dev/agent-setup`).
+
 ## HTTP Endpoints
 
 | Endpoint | Purpose |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Migrating from kafka-lag-exporter? See the **[migration guide](https://klag.dev/
 > AI agents: a machine-readable corpus is at [klag.dev/llms.txt](https://klag.dev/llms.txt).
 > The docs source lives in [`website/`](website/) (Astro + Starlight).
 
+> ### 🤖 Install with your AI agent
+>
+> In Claude Code: `/plugin marketplace add themoah/klag` → `/plugin install klag@klag` → `/klag:install`.
+> It detects Docker/Kubernetes/ArgoCD/Strimzi, deploys, verifies metrics, and can wire up the MCP
+> endpoint (`/klag:connect`, `/klag:diagnose`). Copilot, Codex, Cursor, OpenCode and others:
+> **[klag.dev/agent-setup](https://klag.dev/agent-setup)**.
+
 > **Scales to large clusters:** Monitors thousands of consumer groups in ~50MB heap. Request batching with configurable delays prevents overwhelming brokers — fetch offsets for 500+ groups without spiking cluster CPU.
 
 ## Why Klag?

--- a/TODO.md
+++ b/TODO.md
@@ -26,3 +26,8 @@ In any order:
 Internal tasks:
 * Collect all consts and default values into single AppConfig.
 * Local integration stack with k3s/minicube/docker compose.
+* Shrink the agent-plugin install footprint. `source: "./plugin"` already cut the installed
+  payload from 620 MB (local dir install of the whole repo — node_modules, build/, .env) to
+  36 KB, but a `/plugin marketplace add themoah/klag` still clones the full repo into
+  `~/.claude/plugins/`. Measure it once published; if it is large, look at a shallow/sparse
+  clone, `.gitattributes export-ignore`, or splitting the marketplace into its own repo.

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ In any order:
 
 Internal tasks:
 * Collect all consts and default values into single AppConfig.
-* Local integration stack with k3s/minicube/docker compose.
+* Local integration stack with k3s/minikube/docker compose.
 * Shrink the agent-plugin install footprint. `source: "./plugin"` already cut the installed
   payload from 620 MB (local dir install of the whole repo — node_modules, build/, .env) to
   36 KB, but a `/plugin marketplace add themoah/klag` still clones the full repo into

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "klag",
+  "version": "0.1.0",
+  "description": "Set up Klag (Kafka consumer lag exporter) against your cluster: pick a deployment target, wire Kafka auth, verify metrics, and connect the read-only MCP endpoint.",
+  "author": {
+    "name": "themoah",
+    "email": "aviv@dozorets.com",
+    "url": "https://github.com/themoah"
+  },
+  "homepage": "https://klag.dev",
+  "repository": "https://github.com/themoah/klag",
+  "license": "Apache-2.0",
+  "keywords": [
+    "kafka",
+    "consumer-lag",
+    "monitoring",
+    "prometheus",
+    "mcp"
+  ]
+}

--- a/plugin/commands/connect.md
+++ b/plugin/commands/connect.md
@@ -1,0 +1,83 @@
+---
+description: Connect a running Klag's MCP endpoint to this AI client so the agent can query consumer lag directly
+argument-hint: "[klag-url] (optional, e.g. http://localhost:8888)"
+allowed-tools: [Bash, Read, Write, Edit, WebFetch, AskUserQuestion]
+---
+
+Wire the user's running Klag into their AI client over MCP. URL hint: `$ARGUMENTS`.
+
+Klag's MCP is read-only and served from an in-memory snapshot — it never queries Kafka on
+demand. Tools: `list_consumer_groups`, `get_consumer_group_lag`, `find_lagging_groups`,
+`diagnose`.
+
+## 1. Find the endpoint
+
+If `$ARGUMENTS` has a URL, use it. Otherwise look for a running Klag:
+
+```bash
+docker ps --filter ancestor=themoah/klag --format '{{.Names}} {{.Ports}}'
+kubectl get deploy -A -l app.kubernetes.io/name=klag 2>/dev/null
+```
+
+For a cluster install, start a port-forward (confirm first) and use `http://localhost:18888`:
+
+```bash
+kubectl -n <ns> port-forward svc/klag 18888:8888
+```
+
+A port-forward dies with the shell — tell the user the registration points at a tunnel they
+must keep open, and that a real setup should expose Klag through a Service/Ingress and register
+that URL instead.
+
+## 2. Check the prerequisites
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' <url>/readyz
+# Drop the Authorization line when MCP_AUTH_TOKEN is unset — do not send the literal placeholder.
+curl -s -X POST <url>/mcp -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $KLAG_MCP_TOKEN" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+- `404` on `/mcp` → `MCP_ENABLED` is not `true`. Offer to enable it (`mcp.enabled=true` in the
+  chart, `-e MCP_ENABLED=true` for docker) and redeploy.
+- `401` → `MCP_AUTH_TOKEN` is set; get the token from the user or read it from the Secret with
+  their confirmation. Never print it back.
+- `405` → that was a GET; MCP here is POST only.
+- Empty snapshot → `METRICS_REPORTER` is unset. MCP is populated by the metrics collector, so
+  with no reporter there is nothing to serve.
+
+## 3. Register
+
+Claude Code:
+
+```bash
+claude mcp add --transport http klag <url>/mcp --header "Authorization: Bearer $KLAG_MCP_TOKEN"
+```
+
+Omit the header if no token is set. Pass the token through a shell variable rather than typing it
+inline — a literal token on the command line lands in shell history and in the process list. Prefer user scope over a project `.mcp.json` when the URL is
+a local port-forward, and never commit a real token — `.mcp.json` and `.cursor/mcp.json` are
+usually tracked files.
+
+For other clients, print the snippet for whichever the user is on rather than all of them:
+
+- Cursor — `~/.cursor/mcp.json`: `{"mcpServers":{"klag":{"url":"<url>/mcp","headers":{"Authorization":"Bearer <token>"}}}}`
+- Codex — `~/.codex/config.toml`: `[mcp_servers.klag]` with `url` and
+  `http_headers = { Authorization = "Bearer <token>" }`
+- GitHub Copilot (VS Code) — `.vscode/mcp.json` or user MCP config: top-level `servers.klag`
+  with `"type":"http"`, `"url":"<url>/mcp"`, `"headers":{"Authorization":"Bearer <token>"}`
+- GitHub Copilot CLI — `copilot mcp add --transport http --header "Authorization: Bearer $KLAG_MCP_TOKEN" klag <url>/mcp`
+  or `~/.copilot/mcp-config.json` with `"type":"http"`
+- OpenCode — `opencode.json`: `mcp.servers.klag` with `"type":"remote"`, `"url":"<url>/mcp"`,
+  `"oauth":false`, `"headers":{"Authorization":"Bearer {env:KLAG_MCP_TOKEN}"}`
+- Anything else: Klag needs only a Streamable-HTTP JSON-RPC POST endpoint. Current per-client
+  configs live at `https://klag.dev/ai/mcp/`.
+
+## 4. Verify
+
+Call `list_consumer_groups` (through the registered server if it is live in this session,
+otherwise with the `curl` above) and report the group count and a couple of names. If the client
+needs a restart to pick up the server, say so instead of claiming it works.
+
+Then suggest `/klag:diagnose`.

--- a/plugin/commands/connect.md
+++ b/plugin/commands/connect.md
@@ -12,7 +12,8 @@ demand. Tools: `list_consumer_groups`, `get_consumer_group_lag`, `find_lagging_g
 
 ## 1. Find the endpoint
 
-If `$ARGUMENTS` has a URL, use it. Otherwise look for a running Klag:
+If `$ARGUMENTS` has a URL, use it. Otherwise look for a running Klag. Export the result as
+`KLAG_URL` (and `NS` for the namespace) so the commands below stay quoted and copy-pasteable:
 
 ```bash
 docker ps --filter ancestor=themoah/klag --format '{{.Names}} {{.Ports}}'
@@ -22,7 +23,7 @@ kubectl get deploy -A -l app.kubernetes.io/name=klag 2>/dev/null
 For a cluster install, start a port-forward (confirm first) and use `http://localhost:18888`:
 
 ```bash
-kubectl -n <ns> port-forward svc/klag 18888:8888
+kubectl -n "$NS" port-forward svc/klag 18888:8888
 ```
 
 A port-forward dies with the shell — tell the user the registration points at a tunnel they
@@ -32,9 +33,9 @@ that URL instead.
 ## 2. Check the prerequisites
 
 ```bash
-curl -s -o /dev/null -w '%{http_code}\n' <url>/readyz
+curl -s -o /dev/null -w '%{http_code}\n' "$KLAG_URL/readyz"
 # Drop the Authorization line when MCP_AUTH_TOKEN is unset — do not send the literal placeholder.
-curl -s -X POST <url>/mcp -H 'Content-Type: application/json' \
+curl -s -X POST "$KLAG_URL/mcp" -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $KLAG_MCP_TOKEN" \
   --data '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 ```
@@ -44,15 +45,18 @@ curl -s -X POST <url>/mcp -H 'Content-Type: application/json' \
 - `401` → `MCP_AUTH_TOKEN` is set; get the token from the user or read it from the Secret with
   their confirmation. Never print it back.
 - `405` → that was a GET; MCP here is POST only.
-- Empty snapshot → `METRICS_REPORTER` is unset. MCP is populated by the metrics collector, so
-  with no reporter there is nothing to serve.
+- Empty snapshot → the collector has nothing to publish. Check in this order: `METRICS_REPORTER`
+  is set (default `none` means no collection at all), `/metrics` actually has
+  `klag_consumer_lag` series, `METRICS_GROUP_FILTER` / `METRICS_GROUP_EXCLUDE` do not exclude
+  every group, and the cluster really does have groups with committed offsets. Only the first
+  needs a redeploy.
 
 ## 3. Register
 
 Claude Code:
 
 ```bash
-claude mcp add --transport http klag <url>/mcp --header "Authorization: Bearer $KLAG_MCP_TOKEN"
+claude mcp add --transport http klag "$KLAG_URL/mcp" --header "Authorization: Bearer $KLAG_MCP_TOKEN"
 ```
 
 Omit the header if no token is set. Pass the token through a shell variable rather than typing it
@@ -64,10 +68,12 @@ For other clients, print the snippet for whichever the user is on rather than al
 
 - Cursor — `~/.cursor/mcp.json`: `{"mcpServers":{"klag":{"url":"<url>/mcp","headers":{"Authorization":"Bearer <token>"}}}}`
 - Codex — `~/.codex/config.toml`: `[mcp_servers.klag]` with `url` and
-  `http_headers = { Authorization = "Bearer <token>" }`
+  `bearer_token_env_var = "KLAG_MCP_TOKEN"` (keeps the token out of the config file; export the
+  variable before launching Codex). `http_headers = { Authorization = "Bearer <token>" }` also
+  works but persists the token on disk.
 - GitHub Copilot (VS Code) — `.vscode/mcp.json` or user MCP config: top-level `servers.klag`
   with `"type":"http"`, `"url":"<url>/mcp"`, `"headers":{"Authorization":"Bearer <token>"}`
-- GitHub Copilot CLI — `copilot mcp add --transport http --header "Authorization: Bearer $KLAG_MCP_TOKEN" klag <url>/mcp`
+- GitHub Copilot CLI — `copilot mcp add --transport http --header "Authorization: Bearer $KLAG_MCP_TOKEN" klag "$KLAG_URL/mcp"`
   or `~/.copilot/mcp-config.json` with `"type":"http"`
 - OpenCode — `opencode.json`: `mcp.servers.klag` with `"type":"remote"`, `"url":"<url>/mcp"`,
   `"oauth":false`, `"headers":{"Authorization":"Bearer {env:KLAG_MCP_TOKEN}"}`

--- a/plugin/commands/diagnose.md
+++ b/plugin/commands/diagnose.md
@@ -1,0 +1,61 @@
+---
+description: Triage Kafka consumer lag using a running Klag — rank what is falling behind, diagnose a group, explain the likely cause
+argument-hint: "[consumer-group] (optional — otherwise triage the whole cluster)"
+allowed-tools: [Bash, Read, WebFetch]
+---
+
+Triage consumer lag with the user's running Klag. Group: `$ARGUMENTS` (empty = whole cluster).
+
+Prefer the MCP tools. If the `klag` MCP server is not registered in this session, say so, fall
+back to scraping `/metrics`, and point at `/klag:connect`.
+
+## Path A — MCP (preferred)
+
+1. `find_lagging_groups` (`sortBy`: `lag` | `velocity` | `retention`, `limit`) for the cluster
+   view, or go straight to the named group.
+2. `diagnose <group>` — returns `severity` (`OK` | `INFO` | `WARNING` | `CRITICAL`), a `summary`,
+   and `findings[]` of `{severity, title, detail}`.
+3. `get_consumer_group_lag <group>` when you need per-partition detail. Response keys:
+   `partitions[]` (`lag`, `committedOffset`, `logEndOffset`, `logStartOffset`), `velocity`,
+   `lagMs`, `timeToClose`, `retentionRisk`, `trends`, `overallTrend`, `recentTransitions`,
+   `commitStalenessSeconds`. Read the keys off the response rather than assuming — this list is
+   a convenience, the server is the authority.
+
+Check `snapshotAgeMs` in the response. Anything much older than `METRICS_INTERVAL_MS` means you
+are reading a stale picture — say so rather than diagnosing confidently off it.
+
+## Path B — no MCP
+
+```bash
+curl -s <klag>/metrics | grep -E '^klag_consumer_lag(_sum)?\{|^klag_consumer_commit_staleness_seconds|^klag_consumer_lag_retention_percent|^klag_consumer_group_state|^klag_consumer_lag_velocity'
+```
+
+Same reasoning, less structure. Note in your answer that MCP would give a better one.
+
+## Reading the result
+
+Map findings to causes, worst first:
+
+| Signal | Reading |
+|---|---|
+| state `dead` | group gone — consumers crashed or never restarted. Look at the app, not Kafka. |
+| state `empty` + lag | nobody consuming; work is piling up. |
+| `commitStalenessSeconds` high while lag > 0 | **stuck consumer**: alive but not advancing — poison message, wedged handler, or a blocked downstream. Lag alone misses this. |
+| many `recentTransitions` | rebalance storm / flapping: `max.poll.interval.ms` too low, slow processing, or unstable pods. |
+| `retention_percent` climbing toward 100 | **data loss risk** — messages will expire unread. This outranks raw lag size. |
+| lag growing, velocity positive | producers outpace consumers: scale out, or the partition count caps parallelism. |
+| hot partition | skewed keys, not a consumer problem — repartition or change the key. |
+| under-replicated partitions | broker-side fault tolerance loss, unrelated to the consumer. |
+
+Freshness caveats worth stating when they matter: `commitStalenessSeconds` is *inferred* (Kafka
+exposes no commit timestamp — it measures time since Klag last saw the offset move, and resets on
+Klag restart), and it is only reported while lag > 0.
+
+Background on any of these: `https://klag.dev/guides/detect-stuck-consumers/`,
+`https://klag.dev/metrics/data-loss-prevention/`, `https://klag.dev/guides/troubleshooting/`.
+
+## Output
+
+Lead with the verdict — healthy, or the single worst problem and which group has it. Then the
+evidence (numbers, not adjectives), then the concrete next step. Keep it short. Do not change
+anything in the user's cluster from this command.

--- a/plugin/commands/install.md
+++ b/plugin/commands/install.md
@@ -1,0 +1,86 @@
+---
+description: Install Klag against a Kafka cluster — detects docker/k8s/GitOps, deploys, verifies lag metrics, offers MCP
+argument-hint: "[docker|compose|helm|gitops|jar] (optional — otherwise detected)"
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, WebFetch, AskUserQuestion]
+---
+
+Set up Klag for the user. Target hint: `$ARGUMENTS` (may be empty — then detect).
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/klag/SKILL.md` and
+`${CLAUDE_PLUGIN_ROOT}/skills/klag/references/deploy-targets.md` first. Read
+`references/kafka-connect.md` once you know the Kafka is not a local plaintext one.
+
+**Confirm before every command that mutates the user's machine or cluster**, showing the exact
+command. Detection is read-only and needs no confirmation.
+
+## 1. Detect
+
+Run the detection block from `deploy-targets.md` (docker, kube context, helm, ArgoCD/Flux CRDs,
+Strimzi CRDs, Prometheus Operator CRDs, java). Report what you found in two or three lines.
+
+If the kube context matches `prod|production|prd`, say so explicitly and get a separate
+confirmation before touching it.
+
+## 2. Choose the target
+
+Use `AskUserQuestion`, ordering options by what you detected. If `$ARGUMENTS` names a target, skip
+this step. Options:
+
+- **Demo POC** — the repo's `docker-compose.yaml`: Kafka + Klag + a producer + three misbehaving
+  consumers, so real lag appears in about a minute. Best when the user has no Kafka handy or just
+  wants to see it work. Needs a checkout of `themoah/klag`.
+- **Docker** — one container against their Kafka.
+- **Kubernetes (Helm)** — chart from `https://themoah.github.io/klag`.
+- **GitOps** — ArgoCD `Application` / Flux `HelmRelease` written to their config repo, not applied.
+- **Jar / native** — no docker.
+
+## 3. Kafka connection
+
+Skip for the Demo POC. Otherwise discover the bootstrap servers rather than asking when you can
+(Strimzi CR, `kubectl get svc | grep kafka`, an existing consumer Deployment's env). Confirm the
+value with the user either way, then work out the auth from `references/kafka-connect.md`.
+
+Secrets rule: credentials go into a Kubernetes Secret (`kafka.existingSecret`) or `--set` on the
+command line. Never write them into a `values.yaml` that sits in a git worktree, and never echo
+them back in your output.
+
+Always set `metrics.reporter` / `METRICS_REPORTER` — the default is `none` and produces silence.
+
+## 4. Deploy
+
+Run the commands for the chosen target, one confirmation each. For Helm, write the values file
+first, show it, then `helm upgrade --install`. For GitOps, write the manifest, tell the user which
+file to commit, and stop — do not `kubectl apply`.
+
+## 5. Verify — do not skip this
+
+Port-forward if needed, then:
+
+```bash
+curl -s <klag>/readyz
+curl -s <klag>/metrics | grep '^klag_consumer_lag{' | head
+```
+
+Report the consumer groups Klag actually discovered, by name and count. This is the point of the
+whole command — an install that reports no groups is not a successful install.
+
+If `/readyz` is 503 or the series count is zero, work the failure modes at the end of
+`references/kafka-connect.md` before declaring success. Say plainly what is broken.
+
+## 6. Offer MCP
+
+Once metrics flow, offer to turn on the read-only MCP endpoint so the user's agent can query lag
+directly: `mcp.enabled=true` plus a generated `mcp.authToken` (`openssl rand -hex 24`) stored in a
+Secret, or `-e MCP_ENABLED=true -e MCP_AUTH_TOKEN=...` for docker. If they accept, redeploy and then
+tell them to run `/klag:connect`.
+
+## 7. Offer extras — one line each, apply nothing automatically
+
+- `serviceMonitor.enabled=true`, only if the Prometheus Operator CRD exists.
+- The Grafana dashboard at `dashboard/demo-dashboard.json` in the repo (Dashboards → Import).
+- `metrics.groupFilter` / `metrics.groupExclude` if the cluster has many noisy groups.
+
+## Finish
+
+Summarize in a handful of lines: what runs where, how to reach `/metrics`, which groups are visible,
+and the one next step (`/klag:connect`, or wiring the scrape). Docs: `https://klag.dev`.

--- a/plugin/commands/install.md
+++ b/plugin/commands/install.md
@@ -32,17 +32,19 @@ this step. Options:
 - **Docker** — one container against their Kafka.
 - **Kubernetes (Helm)** — chart from `https://themoah.github.io/klag`.
 - **GitOps** — ArgoCD `Application` / Flux `HelmRelease` written to their config repo, not applied.
-- **Jar / native** — no docker.
+- **Jar / native image** — no docker. The published native build is the `themoah/klag:native`
+  image; a standalone binary needs a source build with GraalVM JDK 21.
 
 ## 3. Kafka connection
 
 Skip for the Demo POC. Otherwise discover the bootstrap servers rather than asking when you can
-(Strimzi CR, `kubectl get svc | grep kafka`, an existing consumer Deployment's env). Confirm the
-value with the user either way, then work out the auth from `references/kafka-connect.md`.
+(Strimzi CR, `kubectl get svc -A | grep -i kafka`, an existing consumer Deployment's env). Confirm
+the value with the user either way, then work out the auth from `references/kafka-connect.md`.
 
-Secrets rule: credentials go into a Kubernetes Secret (`kafka.existingSecret`) or `--set` on the
-command line. Never write them into a `values.yaml` that sits in a git worktree, and never echo
-them back in your output.
+Secrets rule: credentials go into a Kubernetes Secret referenced by `kafka.existingSecret`. That
+is the normal path. `--set kafka.saslJaasConfig=...` is a throwaway-POC shortcut only — it leaves
+the value in the Helm release and in shell history — so name that trade-off when you use it. Never
+write credentials into a `values.yaml` that sits in a git worktree, and never echo them back.
 
 Always set `metrics.reporter` / `METRICS_REPORTER` — the default is `none` and produces silence.
 
@@ -54,11 +56,11 @@ file to commit, and stop — do not `kubectl apply`.
 
 ## 5. Verify — do not skip this
 
-Port-forward if needed, then:
+Port-forward if needed, export the base URL as `KLAG_URL`, then:
 
 ```bash
-curl -s <klag>/readyz
-curl -s <klag>/metrics | grep '^klag_consumer_lag{' | head
+curl -s "$KLAG_URL/readyz"
+curl -s "$KLAG_URL/metrics" | grep '^klag_consumer_lag{' | head
 ```
 
 Report the consumer groups Klag actually discovered, by name and count. This is the point of the
@@ -70,8 +72,10 @@ If `/readyz` is 503 or the series count is zero, work the failure modes at the e
 ## 6. Offer MCP
 
 Once metrics flow, offer to turn on the read-only MCP endpoint so the user's agent can query lag
-directly: `mcp.enabled=true` plus a generated `mcp.authToken` (`openssl rand -hex 24`) stored in a
-Secret, or `-e MCP_ENABLED=true -e MCP_AUTH_TOKEN=...` for docker. If they accept, redeploy and then
+directly: `mcp.enabled=true` plus a generated token (`openssl rand -hex 24`) in a Secret referenced
+by `mcp.existingSecret` — that is the normal path for both Helm and long-lived Docker. `--set
+mcp.authToken=...` and `docker run -e MCP_AUTH_TOKEN=...` are POC exceptions that leave the token
+in the Helm release or the container config; say so when you use them. If they accept, redeploy and
 tell them to run `/klag:connect`.
 
 ## 7. Offer extras — one line each, apply nothing automatically

--- a/plugin/skills/klag/SKILL.md
+++ b/plugin/skills/klag/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: klag
+description: Use when installing, configuring, deploying, or troubleshooting Klag — the Kafka consumer lag exporter (docker, Helm, ArgoCD/Flux, native binary), connecting its MCP endpoint to an AI client, or interpreting its metrics (lag, lag velocity, hot partitions, commit staleness, retention risk). Biases towards retrieval from klag.dev over pre-trained knowledge.
+---
+
+# Klag
+
+Klag exports Kafka consumer lag and group health to Prometheus, Datadog or OTLP. It is
+read-only against Kafka: it needs `Describe` on groups and topics, nothing more.
+
+**Your pre-trained knowledge of Klag's flags and metric names may be outdated. Prefer
+retrieval.** The docs corpus is machine-readable:
+
+- `https://klag.dev/llms.txt` — page index
+- `https://klag.dev/llms-full.txt` — full corpus, one fetch
+- Any page also serves markdown, e.g. `https://klag.dev/configuration/reference/`
+
+Fetch the relevant page before quoting an env var, a chart value or a metric name.
+
+## The three facts that cause most first-run failures
+
+1. **`METRICS_REPORTER` defaults to `none`.** Without `prometheus`, `datadog` or `otlp`,
+   `/metrics` is empty *and* the MCP snapshot is never populated. Nothing errors — it is
+   just silent. Check this first when a fresh install reports no data.
+2. **`KAFKA_BOOTSTRAP_SERVERS` defaults to `localhost:9092`.** In a container or a pod
+   that is almost never right.
+3. **Klag only sees groups that have committed offsets.** A brand-new cluster with no
+   consumers legitimately reports zero groups.
+
+## Config surface
+
+Every setting is an env var. Resolution order, first non-blank wins:
+`NAME` env var → JVM `-DNAME` → dotted `-Dname.dotted` (`HTTP_PORT` → `-Dhttp.port`).
+
+Any `KAFKA_X_Y_Z` env var is lowercased and mapped to the AdminClient property
+`kafka.x.y.z`, so the whole Kafka client surface is reachable without first-class support
+(`KAFKA_SASL_JAAS_CONFIG` → `sasl.jaas.config`). File config layers under env vars:
+classpath `application.properties` < `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
+
+Full list: `https://klag.dev/configuration/reference/`.
+
+## Endpoints (default port 8888)
+
+| Path | Use |
+|---|---|
+| `/healthz` | liveness, always 200 |
+| `/readyz` | 200 when Kafka is reachable, 503 when not |
+| `/metrics` | Prometheus scrape (when `METRICS_REPORTER=prometheus`) |
+| `/version` | build info |
+| `/mcp` | MCP for AI agents, when `MCP_ENABLED=true` |
+
+## References
+
+- `references/deploy-targets.md` — docker, compose demo, Helm, GitOps, native/jar; exact commands.
+- `references/kafka-connect.md` — bootstrap discovery, SASL/TLS matrix, ACLs, Confluent/Strimzi/MSK.
+
+## Rules when acting on a user's environment
+
+- Confirm before every command that mutates a cluster, a host, or a file that is not scratch.
+- Never print, log or commit a secret value. Kafka credentials and `MCP_AUTH_TOKEN` go into a
+  Kubernetes Secret (`kafka.existingSecret`, `mcp.existingSecret`) — never into a `values.yaml`
+  inside a git worktree. `--set mcp.authToken=...`, `docker run -e MCP_AUTH_TOKEN=...` and
+  `claude mcp add --header "...token..."` all leave the value somewhere readable afterwards
+  (Helm release, container config, shell history / process list). Use them only for a throwaway
+  POC, pass the value through a shell variable, and say which of these you used.
+- Quote every value you interpolate into a shell command. Bootstrap addresses, context names and
+  CR fields come from the user's environment, not from you — an unquoted one is a command
+  injection.
+- On an ArgoCD/Flux-managed cluster, write the manifest and stop. Do not `kubectl apply`.
+- Never delete, scale or restart workloads you did not create.
+- Treat a kube context matching `prod|production|prd` as production: say so and ask again.

--- a/plugin/skills/klag/SKILL.md
+++ b/plugin/skills/klag/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: klag
-description: Use when installing, configuring, deploying, or troubleshooting Klag — the Kafka consumer lag exporter (docker, Helm, ArgoCD/Flux, native binary), connecting its MCP endpoint to an AI client, or interpreting its metrics (lag, lag velocity, hot partitions, commit staleness, retention risk). Biases towards retrieval from klag.dev over pre-trained knowledge.
+description: Use when installing, configuring, deploying, or troubleshooting Klag — the Kafka consumer lag exporter (docker, Helm, ArgoCD/Flux, native image), connecting its MCP endpoint to an AI client, or interpreting its metrics (lag, lag velocity, hot partitions, commit staleness, retention risk). Biases towards retrieval from klag.dev over pre-trained knowledge.
 ---
 
 # Klag
 
 Klag exports Kafka consumer lag and group health to Prometheus, Datadog or OTLP. It is
-read-only against Kafka: it needs `Describe` on groups and topics, nothing more.
+read-only against Kafka: it needs `DESCRIBE` on the cluster, on topics, and on groups, nothing
+more. Cluster `DESCRIBE` is required even when group filtering is on — `listConsumerGroups()`
+runs before the filter. Details: `references/kafka-connect.md`.
 
 **Your pre-trained knowledge of Klag's flags and metric names may be outdated. Prefer
 retrieval.** The docs corpus is machine-readable:

--- a/plugin/skills/klag/references/deploy-targets.md
+++ b/plugin/skills/klag/references/deploy-targets.md
@@ -1,0 +1,144 @@
+# Deployment targets
+
+Pick by what the user already has. Detection commands are read-only — run them without asking.
+
+| Signal | Target |
+|---|---|
+| no Kafka at all, wants to see it work | Demo compose stack |
+| `docker info` works, has own Kafka | Single container |
+| `kubectl` + `helm` present | Helm release |
+| ArgoCD or Flux CRDs present | GitOps manifest (write file, do not apply) |
+| no docker, has Java 21 | Fat jar |
+
+Detection:
+
+```bash
+docker info >/dev/null 2>&1 && echo docker-ok
+kubectl config current-context 2>/dev/null
+helm version --short 2>/dev/null
+kubectl get crd applications.argoproj.io -o name 2>/dev/null                       # ArgoCD
+kubectl get crd helmreleases.helm.toolkit.fluxcd.io -o name 2>/dev/null            # Flux
+kubectl get crd kafkas.kafka.strimzi.io -o name 2>/dev/null                        # Strimzi
+kubectl get crd servicemonitors.monitoring.coreos.com -o name 2>/dev/null          # Prometheus Operator
+java -version 2>&1 | head -1
+```
+
+## 1. Demo compose stack (zero-Kafka POC)
+
+The klag repo's `docker-compose.yaml` brings up KRaft Kafka, klag, a producer and three
+deliberately misbehaving consumers (`slow-consumer`, `no-commit-consumer`,
+`delayed-commit-consumer`), so lag appears within a minute. Requires a checkout of
+`https://github.com/themoah/klag`; it builds the klag image locally.
+
+```bash
+docker compose up -d
+curl -s localhost:8888/readyz
+curl -s localhost:8888/metrics | grep -c '^klag_consumer_lag'
+```
+
+Tear down with `docker compose down -v`.
+
+## 2. Single container against the user's Kafka
+
+```bash
+docker run -d --name klag -p 8888:8888 \
+  -e KAFKA_BOOTSTRAP_SERVERS=broker.example.com:9092 \
+  -e METRICS_REPORTER=prometheus \
+  themoah/klag:latest
+```
+
+`themoah/klag:native` is the GraalVM build (~70-100 ms start, ~44 MB RSS). Same tags on
+`ghcr.io/themoah/klag`. Add `-e MCP_ENABLED=true -e MCP_AUTH_TOKEN=...` to expose `/mcp`.
+
+If Kafka runs in another compose network, join it (`--network <net>`) and use the internal
+listener address, not `localhost`.
+
+## 3. Helm
+
+```bash
+helm repo add klag https://themoah.github.io/klag
+helm repo update
+helm upgrade --install klag klag/klag -n kafka-monitoring --create-namespace \
+  -f klag-values.yaml
+```
+
+Minimum `klag-values.yaml`:
+
+```yaml
+kafka:
+  bootstrapServers: "my-cluster-kafka-bootstrap.kafka:9092"
+metrics:
+  reporter: prometheus
+```
+
+Values worth setting on a real install:
+
+| Value | Why |
+|---|---|
+| `metrics.groupFilter` / `metrics.groupExclude` | glob include/exclude; a group is monitored iff it matches an include AND no exclude |
+| `serviceMonitor.enabled: true` | only if the Prometheus Operator CRD exists |
+| `mcp.enabled: true` + `mcp.existingSecret` | expose `/mcp` for agents |
+| `kafka.existingSecret` | JAAS config + truststore password, never inline |
+| `resources` | defaults: 500m/512Mi limits, 100m/256Mi requests |
+
+`replicaCount` stays at 1 — there is no leader election, so >1 double-reports on push sinks
+(Datadog/OTLP). Full values reference: `https://klag.dev/deployment/kubernetes/`.
+
+Verify:
+
+```bash
+kubectl -n kafka-monitoring rollout status deploy/klag
+kubectl -n kafka-monitoring port-forward svc/klag 18888:8888 &
+curl -s localhost:18888/readyz
+curl -s localhost:18888/metrics | grep '^klag_consumer_lag{' | head
+```
+
+## 4. GitOps (ArgoCD / Flux)
+
+Write the manifest into the user's config repo and stop. Do not apply it.
+
+ArgoCD:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: klag
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://themoah.github.io/klag
+    chart: klag
+    # Resolve the current chart version first: `helm search repo klag/klag --versions | head -3`.
+    # Pin an exact version, or a range like `0.3.*` if the user wants patch updates picked up.
+    targetRevision: <chart-version>
+    helm:
+      valuesObject:
+        kafka:
+          bootstrapServers: "my-cluster-kafka-bootstrap.kafka:9092"
+        metrics:
+          reporter: prometheus
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kafka-monitoring
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions: [CreateNamespace=true]
+```
+
+Flux: a `HelmRepository` pointing at `https://themoah.github.io/klag` plus a `HelmRelease`
+with `chart.spec.chart: klag`. Secrets stay out of the committed values — reference an
+existing Secret.
+
+## 5. Fat jar / native binary
+
+Fat jar from the latest GitHub release (`klag-<version>-fat.jar`), Java 21 required:
+
+```bash
+KAFKA_BOOTSTRAP_SERVERS=broker:9092 METRICS_REPORTER=prometheus java -jar klag-*-fat.jar
+```
+
+`-D` works too, including on the native binary: `-Dkafka.bootstrap.servers=broker:9092`.
+No standalone native binary is published — the native build ships as the `:native` image
+tag, or build it from source (`gradle nativeCompile`, GraalVM JDK 21).

--- a/plugin/skills/klag/references/deploy-targets.md
+++ b/plugin/skills/klag/references/deploy-targets.md
@@ -48,7 +48,9 @@ docker run -d --name klag -p 8888:8888 \
 ```
 
 `themoah/klag:native` is the GraalVM build (~70-100 ms start, ~44 MB RSS). Same tags on
-`ghcr.io/themoah/klag`. Add `-e MCP_ENABLED=true -e MCP_AUTH_TOKEN=...` to expose `/mcp`.
+`ghcr.io/themoah/klag`. `latest` and `native` are mutable — fine for a POC, but for anything
+longer-lived pin the release tag (`themoah/klag:0.2.14`, chart `image.tag`) so a later pull
+cannot change the running code. Add `-e MCP_ENABLED=true -e MCP_AUTH_TOKEN=...` to expose `/mcp`.
 
 If Kafka runs in another compose network, join it (`--network <net>`) and use the internal
 listener address, not `localhost`.

--- a/plugin/skills/klag/references/kafka-connect.md
+++ b/plugin/skills/klag/references/kafka-connect.md
@@ -1,0 +1,111 @@
+# Connecting Klag to Kafka
+
+## Finding the bootstrap servers
+
+Ask only if you cannot discover it.
+
+- **Strimzi**: `kubectl get kafka -A` then
+  `kubectl get svc -n <ns> | grep kafka-bootstrap` → `<cluster>-kafka-bootstrap.<ns>:9092`
+  (plain) or `:9093` (TLS). Strimzi's `Kafka` CR also lists listeners under
+  `.status.listeners[].bootstrapServers`.
+- **Any operator/manual deploy**: `kubectl get svc -A | grep -i kafka`.
+- **Confluent Cloud**: `<id>.<region>.<cloud>.confluent.cloud:9092`, always `SASL_SSL`/`PLAIN`.
+- **MSK**: `aws kafka get-bootstrap-brokers --cluster-arn <arn>`.
+- **Local compose**: internal listener (`kafka:29092`), not the host-mapped `localhost:9092`,
+  when Klag runs in the same compose network.
+
+Klag must reach the *advertised* listener, not just the bootstrap host — a bootstrap that
+resolves but advertises unreachable broker hostnames shows up as `/readyz` 503 with timeouts.
+
+## Auth matrix
+
+| Kafka | `KAFKA_SECURITY_PROTOCOL` | `KAFKA_SASL_MECHANISM` | extra |
+|---|---|---|---|
+| local / dev | *(unset)* | — | — |
+| TLS only | `SSL` | — | truststore if the CA is private |
+| SASL over plaintext | `SASL_PLAINTEXT` | `PLAIN` or `SCRAM-SHA-512` | JAAS |
+| SASL over TLS (Confluent Cloud, most prod) | `SASL_SSL` | `PLAIN` or `SCRAM-SHA-512` | JAAS |
+| MSK IAM | **unsupported** | — | see below |
+
+JAAS strings:
+
+```
+# PLAIN (Confluent Cloud: username = API key, password = API secret)
+org.apache.kafka.common.security.plain.PlainLoginModule required username="KEY" password="SECRET";
+
+# SCRAM
+org.apache.kafka.common.security.scram.ScramLoginModule required username="USER" password="PASS";
+```
+
+Env form on docker/jar:
+
+```bash
+-e KAFKA_SECURITY_PROTOCOL=SASL_SSL \
+-e KAFKA_SASL_MECHANISM=PLAIN \
+-e KAFKA_SASL_JAAS_CONFIG='org.apache.kafka.common.security.plain.PlainLoginModule required username="KEY" password="SECRET";'
+```
+
+Helm form — credentials go through a Secret, never inline in a committed `values.yaml`:
+
+```yaml
+kafka:
+  bootstrapServers: "pkc-xxxxx.eu-central-1.aws.confluent.cloud:9092"
+  securityProtocol: SASL_SSL
+  saslMechanism: PLAIN
+  existingSecret: klag-kafka          # keys: jaas-config, truststore-password
+```
+
+```bash
+kubectl -n <ns> create secret generic klag-kafka \
+  --from-literal=jaas-config='org.apache.kafka.common.security.plain.PlainLoginModule required username="KEY" password="SECRET";'
+```
+
+The chart also accepts `kafka.saslJaasConfig` (it creates the Secret for you) — acceptable
+for a throwaway POC via `--set`, not for a file under version control. Key names are
+overridable with `kafka.secretKeys.jaasConfig` / `kafka.secretKeys.truststorePassword`.
+
+Private CA truststore: set `kafka.sslTruststoreLocation` and mount the JKS with
+`extraVolumes` / `extraVolumeMounts`. Note `readOnlyRootFilesystem: true` is the default —
+mount read-only, don't write into the image.
+
+Anything else the Kafka client supports works through the generic mapping: `KAFKA_X_Y_Z` →
+`kafka.x.y.z` (chart: `extraEnv`).
+
+### MSK
+
+SASL/SCRAM and TLS MSK clusters work like any other. **IAM auth does not** — the
+`aws-msk-iam-auth` login module is not on Klag's classpath, so
+`AWS_MSK_IAM`/`sasl.client.callback.handler.class` cannot resolve. Use SCRAM credentials
+from Secrets Manager, or unauthenticated TLS inside the VPC.
+
+## ACLs
+
+Read-only, `DESCRIBE` on three resources. Cluster `DESCRIBE` is **always** required, even
+with group filtering, because `listConsumerGroups()` runs before app-level filtering.
+
+| Resource | Operation |
+|---|---|
+| CLUSTER | DESCRIBE |
+| TOPIC (`*` or prefixed) | DESCRIBE |
+| GROUP (`*` or prefixed) | DESCRIBE |
+
+Commands for self-managed (`kafka-acls`) and Confluent Cloud (`confluent kafka acl create`)
+are at `https://klag.dev/kafka/acl-permissions/`.
+
+Asymmetric ACLs are a real failure mode: if offsets are readable but the topic is not, Klag
+treats the topic as deleted and retires its series. Grant topic DESCRIBE for every topic the
+monitored groups consume.
+
+## Verifying the connection
+
+```bash
+curl -s <klag>/readyz            # 200 = Kafka reachable, 503 = not
+curl -s <klag>/metrics | grep -c '^klag_consumer_lag{'
+```
+
+`/readyz` 503 → bad bootstrap, unreachable advertised listeners, wrong protocol, or bad
+credentials; check Klag's logs for `TimeoutException` (network) vs
+`SaslAuthenticationException` (credentials) vs `TopicAuthorizationException` (ACLs).
+
+200 but zero series → `METRICS_REPORTER` is unset (default `none`), no group has committed
+offsets yet, or `METRICS_GROUP_FILTER` excludes everything.

--- a/plugin/skills/klag/references/kafka-connect.md
+++ b/plugin/skills/klag/references/kafka-connect.md
@@ -56,7 +56,7 @@ kafka:
 ```
 
 ```bash
-kubectl -n <ns> create secret generic klag-kafka \
+kubectl -n "$NS" create secret generic klag-kafka \
   --from-literal=jaas-config='org.apache.kafka.common.security.plain.PlainLoginModule required username="KEY" password="SECRET";'
 ```
 
@@ -99,8 +99,8 @@ monitored groups consume.
 ## Verifying the connection
 
 ```bash
-curl -s <klag>/readyz            # 200 = Kafka reachable, 503 = not
-curl -s <klag>/metrics | grep -c '^klag_consumer_lag{'
+curl -s "$KLAG_URL/readyz"            # 200 = Kafka reachable, 503 = not
+curl -s "$KLAG_URL/metrics" | grep -c '^klag_consumer_lag{'
 ```
 
 `/readyz` 503 → bad bootstrap, unreachable advertised listeners, wrong protocol, or bad

--- a/scripts/check-plugin.sh
+++ b/scripts/check-plugin.sh
@@ -50,8 +50,13 @@ shopt -s nullglob
 files=(plugin/commands/*.md plugin/skills/klag/SKILL.md)
 [ ${#files[@]} -gt 1 ] || err "no plugin/commands/*.md found"
 for f in "${files[@]}"; do
-  head -1 "$f" | grep -qx -- '---' || err "$f: missing YAML frontmatter"
-  grep -qE '^(description|name):' "$f" || err "$f: frontmatter has no description"
+  # Only look between the opening and closing --- : a `description:` in the body does not count.
+  awk '
+    NR == 1 { if ($0 != "---") exit 1; next }
+    /^---[[:space:]]*$/ { closed = 1; exit }
+    /^description:[[:space:]]*[^[:space:]]/ { found = 1 }
+    END { exit (closed && found) ? 0 : 1 }
+  ' "$f" || err "$f: frontmatter missing or has no non-empty description:"
 done
 
 # Referenced reference files must exist (a dangling ${CLAUDE_PLUGIN_ROOT} path is a silent no-op).

--- a/scripts/check-plugin.sh
+++ b/scripts/check-plugin.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Validates the Claude Code plugin shipped from this repo:
+#   .claude-plugin/marketplace.json   (marketplace, must sit at the repo root)
+#   plugin/                            (the plugin itself — installs copy only this subtree)
+# The plugin only loads if the manifests parse and the component dirs sit at the plugin root,
+# so this catches the failure modes that would otherwise only show up in a user's client.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+fail=0
+err() { echo "FAIL: $*" >&2; fail=1; }
+
+python3 - <<'PY' || fail=1
+import json, sys
+
+with open("plugin/.claude-plugin/plugin.json") as f:
+    plugin = json.load(f)
+with open(".claude-plugin/marketplace.json") as f:
+    market = json.load(f)
+
+ok = True
+if plugin.get("name") != "klag":
+    print(f"FAIL: plugin.json name is {plugin.get('name')!r}, expected 'klag'"
+          " (it namespaces the commands: /klag:install)", file=sys.stderr)
+    ok = False
+# Enumerating these replaces the convention default; we rely on discovery of plugin/commands/.
+for key in ("commands", "agents", "hooks", "mcpServers"):
+    if key in plugin:
+        print(f"FAIL: plugin.json sets {key!r}, which replaces the convention default", file=sys.stderr)
+        ok = False
+entries = {p.get("name"): p.get("source") for p in market.get("plugins", [])}
+if "klag" not in entries:
+    print(f"FAIL: marketplace.json lists no 'klag' plugin (found {list(entries)})", file=sys.stderr)
+    ok = False
+elif entries["klag"] != "./plugin":
+    # "./" would make every install copy the whole repo (~600MB with node_modules).
+    print(f"FAIL: marketplace source is {entries['klag']!r}, expected './plugin'", file=sys.stderr)
+    ok = False
+sys.exit(0 if ok else 1)
+PY
+
+# Component dirs must be at the plugin root, never inside .claude-plugin/.
+for stray in plugin/.claude-plugin/commands plugin/.claude-plugin/skills plugin/.claude-plugin/agents; do
+  [ -e "$stray" ] && err "$stray must live at the plugin root, not inside .claude-plugin/"
+done
+
+[ -f plugin/skills/klag/SKILL.md ] || err "plugin/skills/klag/SKILL.md missing"
+
+shopt -s nullglob
+files=(plugin/commands/*.md plugin/skills/klag/SKILL.md)
+[ ${#files[@]} -gt 1 ] || err "no plugin/commands/*.md found"
+for f in "${files[@]}"; do
+  head -1 "$f" | grep -qx -- '---' || err "$f: missing YAML frontmatter"
+  grep -qE '^(description|name):' "$f" || err "$f: frontmatter has no description"
+done
+
+# Referenced reference files must exist (a dangling ${CLAUDE_PLUGIN_ROOT} path is a silent no-op).
+for ref in $(grep -ohE 'references/[a-z0-9-]+\.md' plugin/commands/*.md plugin/skills/klag/SKILL.md | sort -u); do
+  [ -f "plugin/skills/klag/$ref" ] || err "referenced plugin/skills/klag/$ref does not exist"
+done
+
+# Deeper schema check, local only — the claude CLI is not on CI runners, so CI gets the
+# structural checks above and nothing more. Run this script locally before releasing a plugin
+# change if you want the schema validated.
+if command -v claude >/dev/null 2>&1; then
+  claude plugin validate . >/dev/null || err "claude plugin validate . failed"
+  claude plugin validate ./plugin >/dev/null || err "claude plugin validate ./plugin failed"
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "Plugin manifests OK (${#files[@]} component files)."
+else
+  exit 1
+fi

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig({
   // Short links for the README and external references.
   redirects: {
     '/migration': '/getting-started/migrating-from-kafka-lag-exporter/',
+    '/agent-setup': '/ai/agent-setup/',
     '/getting-started/comparison': '/comparisons/overview/',
     '/comparisons': '/comparisons/overview/',
     '/comparisons/': '/comparisons/overview/',
@@ -132,6 +133,7 @@ export default defineConfig({
         {
           label: 'AI Agents',
           items: [
+            { label: 'Agent Setup', slug: 'ai/agent-setup' },
             { label: 'MCP Endpoint', slug: 'ai/mcp' },
           ],
         },

--- a/website/src/content/docs/ai/agent-setup.mdx
+++ b/website/src/content/docs/ai/agent-setup.mdx
@@ -85,8 +85,13 @@ Connect a running Klag over MCP by adding it to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.klag]
 url = "https://klag.example.com/mcp"
-http_headers = { Authorization = "Bearer <token>" }
+bearer_token_env_var = "KLAG_MCP_TOKEN"
 ```
+
+`bearer_token_env_var` names the environment variable holding the token, so the value never
+lands in `config.toml`. Export it (same value as Klag's `MCP_AUTH_TOKEN`) before launching
+Codex. A literal `http_headers = { Authorization = "Bearer <token>" }` also works, at the cost
+of storing the token on disk.
 
   </TabItem>
   <TabItem label="GitHub Copilot">

--- a/website/src/content/docs/ai/agent-setup.mdx
+++ b/website/src/content/docs/ai/agent-setup.mdx
@@ -1,0 +1,223 @@
+---
+title: Agent Setup
+description: Install and run Klag from your AI coding agent. Add the Klag plugin to Claude Code for /klag:install, /klag:connect and /klag:diagnose, or point Copilot, Codex, Cursor, OpenCode and other agents at the machine-readable docs.
+---
+
+import { Tabs, TabItem, Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Klag ships a plugin for AI coding agents. Instead of reading this site and assembling the
+deployment yourself, you tell the agent to install Klag and it works out the rest: where to run
+it, how to reach your Kafka, whether the metrics actually arrived.
+
+The plugin is thin on purpose. It carries the decision procedure and the verification steps, and
+fetches the details from these docs, so it does not drift when Klag changes.
+
+## Claude Code
+
+<Steps>
+
+1. Add the marketplace and install the plugin:
+
+   ```txt
+   /plugin marketplace add themoah/klag
+   /plugin install klag@klag
+   ```
+
+2. Run the installer:
+
+   ```txt
+   /klag:install
+   ```
+
+   It detects what you have — Docker, a kube context, Helm, ArgoCD or Flux, Strimzi — asks where
+   to deploy, wires up the Kafka connection, and then verifies that `/readyz` is green and
+   `klag_consumer_lag` series are actually being exported. It confirms with you before every
+   command that changes anything.
+
+3. Let it turn on the [MCP endpoint](/ai/mcp/), then connect your agent to it:
+
+   ```txt
+   /klag:connect
+   ```
+
+4. Ask about your lag:
+
+   ```txt
+   /klag:diagnose payments-service
+   ```
+
+</Steps>
+
+### What the plugin gives you
+
+| Command | Does |
+|---|---|
+| `/klag:install` | Detect environment → deploy (compose demo, Docker, Helm, GitOps manifest, or jar) → verify metrics → offer MCP |
+| `/klag:connect` | Register a running Klag's MCP endpoint with your agent and confirm it answers |
+| `/klag:diagnose` | Rank what is falling behind and explain why: stuck consumers, rebalance storms, retention risk, hot partitions |
+
+It also installs a `klag` skill, so an agent that has it will use Klag's real configuration
+surface when you simply ask it to "set up Kafka lag monitoring" — no slash command needed.
+
+:::note[No Kafka handy?]
+Ask for the demo target. `/klag:install` brings up the repo's Compose stack — Kafka, Klag, a
+producer, and three deliberately misbehaving consumers — so there is real lag to look at within
+about a minute.
+:::
+
+## Other agents
+
+The plugin's commands are Claude Code specific, but nothing else here is. Every agent can use
+Klag's machine-readable docs, and any MCP-capable client can query a running Klag.
+
+<Tabs>
+  <TabItem label="Codex">
+
+Point it at the docs corpus, then let it install:
+
+```txt
+Read https://klag.dev/llms-full.txt, then set up Klag against my Kafka cluster
+and verify that /metrics is exporting klag_consumer_lag.
+```
+
+Connect a running Klag over MCP by adding it to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.klag]
+url = "https://klag.example.com/mcp"
+http_headers = { Authorization = "Bearer <token>" }
+```
+
+  </TabItem>
+  <TabItem label="GitHub Copilot">
+
+Same install prompt works in VS Code Copilot Chat (Agent mode), Copilot CLI, or Visual Studio:
+
+```txt
+Read https://klag.dev/llms-full.txt, then set up Klag against my Kafka cluster
+and verify that /metrics is exporting klag_consumer_lag.
+```
+
+**VS Code** — add to `.vscode/mcp.json` (workspace) or your user MCP config
+(`MCP: Open User Configuration`). Prefer `${input:...}` for the token so it is not
+stored in plain text:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "klag-mcp-token",
+      "description": "Klag MCP token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "klag": {
+      "type": "http",
+      "url": "https://klag.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${input:klag-mcp-token}" }
+    }
+  }
+}
+```
+
+**Copilot CLI** — add to `~/.copilot/mcp-config.json` or run once from the terminal:
+
+```shell
+copilot mcp add --transport http \
+  --header "Authorization: Bearer <token>" \
+  klag https://klag.example.com/mcp
+```
+
+  </TabItem>
+  <TabItem label="Cursor">
+
+Same prompt works. For MCP, add to `~/.cursor/mcp.json` (global — keep tokens out of the
+project file, which is usually committed):
+
+```json
+{
+  "mcpServers": {
+    "klag": {
+      "url": "https://klag.example.com/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
+
+  </TabItem>
+  <TabItem label="OpenCode">
+
+Same install prompt in the terminal agent:
+
+```txt
+Read https://klag.dev/llms-full.txt, then set up Klag against my Kafka cluster
+and verify that /metrics is exporting klag_consumer_lag.
+```
+
+For MCP, add to `~/.config/opencode/opencode.json` (global) or `opencode.json` in your
+project. Use `oauth: false` when Klag expects a bearer token instead of OAuth discovery:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "klag": {
+        "type": "remote",
+        "url": "https://klag.example.com/mcp",
+        "oauth": false,
+        "headers": {
+          "Authorization": "Bearer {env:KLAG_MCP_TOKEN}"
+        }
+      }
+    }
+  }
+}
+```
+
+Older OpenCode builds place servers directly under `mcp` instead of `mcp.servers` — same
+fields, flatter nesting.
+
+  </TabItem>
+  <TabItem label="Anything else">
+
+Klag needs no agent-specific SDK. Two things are portable:
+
+- **Docs**: [`llms.txt`](https://klag.dev/llms.txt) (page index) and
+  [`llms-full.txt`](https://klag.dev/llms-full.txt) (whole corpus in one fetch). Every page also
+  serves markdown.
+- **MCP**: Klag speaks Streamable HTTP (JSON-RPC 2.0 over POST) at `/mcp`. Any client with
+  remote-MCP support connects with just the URL and a bearer token.
+
+Per-client MCP configurations live on the [MCP Endpoint](/ai/mcp/) page.
+
+  </TabItem>
+</Tabs>
+
+## What it will and will not do
+
+The installer runs real commands, so it is deliberately fenced in:
+
+- It confirms before every command that mutates your machine or cluster. Detection is read-only.
+- Kafka credentials and the MCP token go into a Kubernetes Secret or a `--set` flag — never into a
+  `values.yaml` inside your git worktree, and never echoed back to you.
+- On an ArgoCD- or Flux-managed cluster it **writes** the `Application` / `HelmRelease` and stops.
+  It does not `kubectl apply` behind GitOps.
+- It never deletes, scales or restarts workloads it did not create.
+- A kube context that looks like production is called out, and needs a second confirmation.
+
+## Next
+
+<CardGrid>
+  <LinkCard title="MCP Endpoint" href="/ai/mcp/" description="The read-only tools your agent gets: list groups, per-group lag, triage, diagnose." />
+  <LinkCard title="Manual installation" href="/getting-started/installation/" description="Docker, Helm, and jar instructions if you would rather do it yourself." />
+  <LinkCard title="Configuration reference" href="/configuration/reference/" description="Every environment variable, with defaults." />
+  <LinkCard title="Troubleshooting" href="/guides/troubleshooting/" description="503 on /readyz, empty /metrics, MCP 401/405." />
+</CardGrid>
+
+The plugin source lives in the Klag repo itself, under
+[`plugin/`](https://github.com/themoah/klag/tree/main/plugin) — one source of truth, versioned
+with Klag.

--- a/website/src/content/docs/ai/mcp.md
+++ b/website/src/content/docs/ai/mcp.md
@@ -191,6 +191,86 @@ Older Codex builds only spoke stdio and needed the `mcp-remote` bridge
 (`command = "npx"`, `args = ["mcp-remote", "https://klag.example.com/mcp"]`). Check your
 Codex version's MCP docs if the `url` form isn't recognized.
 
+### GitHub Copilot
+
+**VS Code** — add to `.vscode/mcp.json` (workspace) or your user MCP config. VS Code uses
+the top-level key `servers`, not `mcpServers`. Prefer `${input:...}` for tokens:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "klag-mcp-token",
+      "description": "Klag MCP token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "klag": {
+      "type": "http",
+      "url": "https://klag.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${input:klag-mcp-token}" }
+    }
+  }
+}
+```
+
+Switch Copilot Chat to **Agent** mode and confirm the server appears under the tools picker.
+
+**Copilot CLI** — add to `~/.copilot/mcp-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "klag": {
+      "type": "http",
+      "url": "https://klag.example.com/mcp",
+      "headers": { "Authorization": "Bearer <token>" },
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Or from the terminal:
+
+```shell
+copilot mcp add --transport http \
+  --header "Authorization: Bearer <token>" \
+  klag https://klag.example.com/mcp
+```
+
+Visual Studio and JetBrains IDEs use the same `servers` object in `mcp.json`; remote
+servers can also use `requestInit.headers` instead of `headers`.
+
+### OpenCode
+
+Add to `~/.config/opencode/opencode.json` (global) or `opencode.json` in your project.
+OpenCode v2 nests servers under `mcp.servers`. Set `oauth: false` when Klag uses a bearer
+token — otherwise OpenCode may attempt OAuth discovery first:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "klag": {
+        "type": "remote",
+        "url": "https://klag.example.com/mcp",
+        "oauth": false,
+        "headers": {
+          "Authorization": "Bearer {env:KLAG_MCP_TOKEN}"
+        }
+      }
+    }
+  }
+}
+```
+
+Use `{env:VAR}` for secret interpolation. Older OpenCode builds place servers directly
+under `mcp` with the same fields.
+
 ### Kilo Code
 
 Open the MCP settings (`mcp_settings.json`) and add:

--- a/website/src/content/docs/ai/mcp.md
+++ b/website/src/content/docs/ai/mcp.md
@@ -184,8 +184,12 @@ Add to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.klag]
 url = "https://klag.example.com/mcp"
-http_headers = { Authorization = "Bearer <token>" }
+bearer_token_env_var = "KLAG_MCP_TOKEN"
 ```
+
+`bearer_token_env_var` names the environment variable that holds the token, so it is never
+written to `config.toml` — export it before launching Codex. The inline form
+`http_headers = { Authorization = "Bearer <token>" }` works too, but stores the token on disk.
 
 Older Codex builds only spoke stdio and needed the `mcp-remote` bridge
 (`command = "npx"`, `args = ["mcp-remote", "https://klag.example.com/mcp"]`). Check your

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -11,6 +11,10 @@ hero:
       link: /getting-started/quick-start/
       icon: right-arrow
       variant: primary
+    - text: Set up with your AI agent
+      link: /ai/agent-setup/
+      icon: rocket
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/themoah/klag
       icon: external
@@ -90,6 +94,20 @@ gateway IP directly).
 Metrics land at `http://localhost:8888/metrics`. See the [Quick Start](/getting-started/quick-start/)
 for native image, Helm, and Docker env-file options.
 
+## Or let your agent do it
+
+In Claude Code, add the Klag plugin and run the installer:
+
+```txt
+/plugin marketplace add themoah/klag
+/plugin install klag@klag
+/klag:install
+```
+
+It detects Docker, your kube context, Helm, ArgoCD/Flux and Strimzi, deploys accordingly,
+and verifies that lag metrics actually arrive. Copilot, Codex, Cursor, OpenCode and other
+agents are covered too — see [Agent Setup](/ai/agent-setup/).
+
 ## Ships to your stack
 
 <CardGrid>
@@ -103,7 +121,8 @@ for native image, Helm, and Docker env-file options.
 
 Klag exposes an opt-in, read-only [MCP endpoint](/ai/mcp/) so SRE and dev agents can
 query lag, find lagging groups, and run composite `diagnose` checks, served from an
-in-memory snapshot, never touching your brokers.
+in-memory snapshot, never touching your brokers. Installation and connection are
+agent-driven too — see [Agent Setup](/ai/agent-setup/).
 
 ---
 


### PR DESCRIPTION
## Summary by Sourcery

Add a Claude Code agent-onboarding plugin for Klag and document agent-based installation and MCP connectivity across popular AI coding tools.

Enhancements:
- Introduce a Claude Code plugin (skills, commands, references, manifests) to automate installing, connecting, and diagnosing Klag from AI coding agents.
- Add a validation script for the Claude plugin and describe its structure and footprint considerations in contributor docs and TODOs.

CI:
- Extend the build workflow to detect plugin-related changes and run a plugin validation script in CI.

Documentation:
- Add an Agent Setup guide and link it from the homepage, navigation, and README to walk users through installing Klag via Claude Code and configuring MCP access for Claude, Copilot, Codex, Cursor, OpenCode, and other agents.
- Update MCP documentation to include concrete MCP configuration examples for GitHub Copilot and OpenCode, and reference the new Agent Setup flow from existing docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claude Code plugin for installing, connecting, and diagnosing Klag deployments.
  * Added guided workflows for Kafka configuration, deployment verification, MCP setup, and consumer-lag troubleshooting.
  * Added support guidance for Claude Code, Codex, GitHub Copilot, Cursor, OpenCode, and other MCP clients.

* **Documentation**
  * Added an Agent Setup guide with installation, security, and production-safety instructions.
  * Added setup guidance for GitHub Copilot and OpenCode.
  * Added navigation and redirects to the new documentation.

* **Quality**
  * Added automated validation for plugin manifests and required components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->