### PR TITLE
feat(metrics): trust extra CAs for OTLP export over HTTPS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,14 +171,16 @@ See `docs/superpowers/specs/2026-06-01-mcp-support-design.md`.
 - `OTEL_METRIC_EXPORT_INTERVAL` - Export interval in milliseconds (default: 60000)
 - `OTEL_SERVICE_NAME` - Service name for resource attributes (default: klag)
 - `OTEL_RESOURCE_ATTRIBUTES` - Additional resource attributes (format: key1=value1,key2=value2)
+- `OTEL_EXPORTER_OTLP_CERTIFICATE` - Path to a PEM CA bundle the exporter additionally trusts (for an HTTPS collector with an internally-signed cert). Added on top of the JVM default trust, never replacing it, and scoped to the OTLP exporter (Kafka TLS is unaffected).
 
 *Custom Variables (override OTEL_* vars):*
 - `OTLP_ENDPOINT` - Direct endpoint URL (default: http://localhost:4318/v1/metrics)
 - `OTLP_STEP_MS` - Export interval in milliseconds (default: 60000)
 - `OTLP_HEADERS` - Authentication headers (format: key1=value1,key2=value2)
 - `OTLP_RESOURCE_ATTRIBUTES` - Resource attributes (format: key1=value1,key2=value2)
+- `OTLP_CA_CERT_PATH` (overrides `OTEL_EXPORTER_OTLP_CERTIFICATE`) - Path to a PEM CA bundle the exporter additionally trusts, for an HTTPS collector with an internally-signed cert. Trust is additive over the JVM defaults (never reduced). If set but the file is missing/empty/unparseable, OTLP registry creation fails fast rather than silently falling back to default trust.
 
-*Note:* Protocol is HTTP only (port 4318). Aggregation temporality is cumulative.
+*Note:* Protocol is HTTP only (port 4318); both `http://` and `https://` endpoints are supported (point `OTLP_CA_CERT_PATH` at the CA bundle for an internally-signed HTTPS collector). Aggregation temporality is cumulative.
 
 *Example for Grafana Cloud:*
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.14"
+version = "0.2.15"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -35,4 +35,4 @@ annotations:
       email: aviv@dozorets.com
   artifacthub.io/changes: |
     - kind: added
-      description: OTLP exporter can trust extra CA certificates for an HTTPS collector served with an internally-signed cert; set metrics.otlp.caCertPath (env OTLP_CA_CERT_PATH / OTEL_EXPORTER_OTLP_CERTIFICATE) to a PEM bundle mounted via extraVolumes. Trust is additive over the JVM defaults and scoped to the OTLP exporter
+      description: OTLP exporter can trust extra CA certificates for an HTTPS collector served with an internally-signed cert; set metrics.otlp.caCertPath (env OTLP_CA_CERT_PATH / OTEL_EXPORTER_OTLP_CERTIFICATE) to a PEM bundle mounted with matching extraVolumes and extraVolumeMounts. Trust is additive over the JVM defaults and scoped to the OTLP exporter

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.9
-appVersion: "0.2.14"
+version: 0.3.10
+appVersion: "0.2.15"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -34,39 +34,5 @@ annotations:
     - name: themoah
       email: aviv@dozorets.com
   artifacthub.io/changes: |
-    - kind: security
-      description: Upgrade Micrometer to 1.16.6 (CVE-2026-40984 in micrometer-core; the 1.12 line is EOL and unpatched), which moves the Prometheus registry onto the Prometheus Java client 1.x and drops the EOL io.prometheus:simpleclient jars; scraped metric names, labels and values are unchanged
-    - kind: changed
-      description: Drop the unused vertx-micrometer-metrics dependency
-    - kind: fixed
-      description: A topic deleted while a group still has committed offsets for it no longer keeps every cycle partial (which froze stale-series cleanup for up to offsets.retention.minutes); such topics are filtered out and their series retired
-    - kind: fixed
-      description: The MCP snapshot now refreshes on a partial cycle instead of freezing at the last complete one, so one failing consumer group no longer leaves AI agents reading stale data while /metrics stays current
     - kind: added
-      description: KIP-848 consumer-protocol group states (assigning, reconciling) are reported as their own state tag values instead of collapsing to unknown; rebalance alerts should match all four rebalance states
-    - kind: changed
-      description: Batch topic offset lookups into one describeTopics + three listOffsets per cycle (per chunk when KAFKA_CHUNK_COUNT > 1) instead of four admin requests per topic, cutting broker load and cycle time on clusters with many topics
-    - kind: added
-      description: KAFKA_MAX_CONCURRENT_GROUPS (default 50) bounds how many consumer-group offset requests are in flight at once
-    - kind: fixed
-      description: Leaderless (offline) partitions no longer throw while reading topic metadata, which previously dropped the whole topic from a collection cycle
-    - kind: changed
-      description: Enable Java 21 virtual threads by default (app.useVirtualThreads=true); set false for event-loop deployment
-    - kind: fixed
-      description: Keep JVM alive when virtual threads are enabled (KlagLauncher blocks until shutdown)
-    - kind: added
-      description: Per-partition breakdown of klag.consumer.lag.ms and klag.consumer.lag.retention_percent (topic-level aggregate kept as the partition-less series; select it with {partition=""}, drill down with {partition!=""})
-    - kind: changed
-      description: klag.consumer.lag.sum/.max/.min now carry a topic label (per consumer_group+topic); the group total is recoverable via sum by(consumer_group)(klag_consumer_lag_sum)
-    - kind: added
-      description: ISR (in-sync replica) monitoring - klag.partition.under_replicated flags partitions with fewer in-sync replicas than configured; surfaced in the diagnose MCP tool; opt out with ISR_ENABLED=false
-    - kind: added
-      description: Per-consumer-instance member labels (member_host, consumer_id, client_id) on consumer-owned lag metrics for kafka-lag-exporter parity; opt out with CONSUMER_MEMBER_LABELS_ENABLED=false
-    - kind: fixed
-      description: Stale gauges are now actually removed from the registry (key-format mismatch left old series lingering on /metrics)
-    - kind: fixed
-      description: Klag no longer exits (and crash-loops) when Kafka is unreachable during the first metrics collection; the first cycle now degrades like the health monitor
-    - kind: fixed
-      description: Topic names containing ':' no longer break every collection cycle (hot-partition throughput detection parsed the topic out of its internal key)
-    - kind: fixed
-      description: A cycle that observes no consumer groups now runs the full cycle-end cleanup and refreshes the MCP snapshot instead of leaving stale tracker history and a frozen snapshot
+      description: OTLP exporter can trust extra CA certificates for an HTTPS collector served with an internally-signed cert; set metrics.otlp.caCertPath (env OTLP_CA_CERT_PATH / OTEL_EXPORTER_OTLP_CERTIFICATE) to a PEM bundle mounted via extraVolumes. Trust is additive over the JVM defaults and scoped to the OTLP exporter

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -143,6 +143,7 @@ Set `KLAG_CONFIG_FILE` to the path of an external `application.properties` (typi
 | `metrics.otlp.headers` | Authentication headers (key1=value1,key2=value2) | `""` |
 | `metrics.otlp.serviceName` | Service name for OTEL_SERVICE_NAME | `klag` |
 | `metrics.otlp.resourceAttributes` | Additional resource attributes | `""` |
+| `metrics.otlp.caCertPath` | Path to a PEM CA bundle the exporter additionally trusts, for an HTTPS collector with an internally-signed cert (maps to `OTLP_CA_CERT_PATH`; added on top of JVM defaults). Mount it via `extraVolumes`/`extraVolumeMounts`. | `""` |
 | `metrics.otlp.existingSecret` | Existing secret for OTLP headers | `""` |
 | `metrics.otlp.secretKeys.headers` | Key in secret for headers | `otlp-headers` |
 

--- a/charts/klag/templates/deployment.yaml
+++ b/charts/klag/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
             - name: OTLP_STEP_MS
               value: {{ .Values.metrics.otlp.stepMs | quote }}
             {{- end }}
+            {{- if .Values.metrics.otlp.caCertPath }}
+            - name: OTLP_CA_CERT_PATH
+              value: {{ .Values.metrics.otlp.caCertPath | quote }}
+            {{- end }}
             {{- end }}
             # Datadog configuration (when reporter is datadog)
             {{- if eq .Values.metrics.reporter "datadog" }}

--- a/charts/klag/tests/test-values-otlp.yaml
+++ b/charts/klag/tests/test-values-otlp.yaml
@@ -9,3 +9,4 @@ metrics:
     headers: "Authorization=Basic dGVzdDp0ZXN0"
     serviceName: "klag-test"
     resourceAttributes: "environment=test,cluster=ci"
+    caCertPath: "/etc/shared-certificates/internal-https/collector.crt"

--- a/charts/klag/values.yaml
+++ b/charts/klag/values.yaml
@@ -110,6 +110,12 @@ metrics:
     # OTLP export interval in milliseconds (maps to OTLP_STEP_MS env var).
     # Leave empty to fall back to OTEL_METRIC_EXPORT_INTERVAL or the app default (60000).
     stepMs: ""
+    # Path to a PEM CA bundle the OTLP exporter should additionally trust (maps to
+    # OTLP_CA_CERT_PATH). Set this when the collector is served over HTTPS with an
+    # internally-signed certificate; the CAs are added on top of the JVM defaults, never
+    # replacing them. Mount the bundle with extraVolumes/extraVolumeMounts. Empty = JVM
+    # default trust only.
+    caCertPath: ""
     # Use an existing secret for OTLP headers
     existingSecret: ""
     secretKeys:

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -122,6 +122,7 @@ validate_output "OTLP_ENDPOINT set" "${TESTS_DIR}/test-values-otlp.yaml" "OTLP_E
 validate_output "OTEL_SERVICE_NAME set" "${TESTS_DIR}/test-values-otlp.yaml" "OTEL_SERVICE_NAME"
 validate_output "OTLP secret created" "${TESTS_DIR}/test-values-otlp.yaml" "name: test-release-klag-otlp"
 validate_output "OTLP_CA_CERT_PATH set when caCertPath given" "${TESTS_DIR}/test-values-otlp.yaml" "OTLP_CA_CERT_PATH"
+validate_not_present "OTLP_CA_CERT_PATH absent when caCertPath empty" "${TESTS_DIR}/test-values-otlp.yaml" "OTLP_CA_CERT_PATH" "--set metrics.otlp.caCertPath="
 validate_not_present "OTLP_CA_CERT_PATH absent by default" "" "OTLP_CA_CERT_PATH"
 
 # Datadog config validation

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -121,6 +121,8 @@ validate_output "JAAS config from secret" "${TESTS_DIR}/test-values-sasl.yaml" "
 validate_output "OTLP_ENDPOINT set" "${TESTS_DIR}/test-values-otlp.yaml" "OTLP_ENDPOINT"
 validate_output "OTEL_SERVICE_NAME set" "${TESTS_DIR}/test-values-otlp.yaml" "OTEL_SERVICE_NAME"
 validate_output "OTLP secret created" "${TESTS_DIR}/test-values-otlp.yaml" "name: test-release-klag-otlp"
+validate_output "OTLP_CA_CERT_PATH set when caCertPath given" "${TESTS_DIR}/test-values-otlp.yaml" "OTLP_CA_CERT_PATH"
+validate_not_present "OTLP_CA_CERT_PATH absent by default" "" "OTLP_CA_CERT_PATH"
 
 # Datadog config validation
 validate_output "DD_API_KEY set" "${TESTS_DIR}/test-values-datadog.yaml" "DD_API_KEY"

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerConfig.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerConfig.java
@@ -28,6 +28,12 @@ public final class MicrometerConfig {
 
   private static final Logger log = LoggerFactory.getLogger(MicrometerConfig.class);
 
+  // Timeouts for the custom OTLP HTTP sender (used only on the extra-CA-trust path). Mirrors the
+  // former PushRegistryConfig defaults, whose connectTimeout()/readTimeout() are deprecated in
+  // Micrometer 1.16; the sender owns its timeouts now instead of reading them off the registry config.
+  private static final Duration OTLP_CONNECT_TIMEOUT = Duration.ofSeconds(1);
+  private static final Duration OTLP_READ_TIMEOUT = Duration.ofSeconds(10);
+
   private MicrometerConfig() {}
 
   /**
@@ -211,7 +217,7 @@ public final class MicrometerConfig {
     OtlpMeterRegistry registry = tls
         .map(ctx -> OtlpMeterRegistry.builder(config)
             .metricsSender(new OtlpHttpMetricsSender(
-                OtlpTls.httpSender(ctx, config.connectTimeout(), config.readTimeout())))
+                OtlpTls.httpSender(ctx, OTLP_CONNECT_TIMEOUT, OTLP_READ_TIMEOUT)))
             .build())
         .orElseGet(() -> new OtlpMeterRegistry(config, Clock.SYSTEM));
     log.info("OTLP registry created - endpoint: {}, temporality: {}, customCaTrust: {}",

--- a/src/main/java/io/github/themoah/klag/metrics/MicrometerConfig.java
+++ b/src/main/java/io/github/themoah/klag/metrics/MicrometerConfig.java
@@ -12,9 +12,12 @@ import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.AggregationTemporality;
 import io.micrometer.registry.otlp.OtlpConfig;
+import io.micrometer.registry.otlp.OtlpHttpMetricsSender;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -201,9 +204,18 @@ public final class MicrometerConfig {
       }
     };
 
-    OtlpMeterRegistry registry = new OtlpMeterRegistry(config, Clock.SYSTEM);
-    log.info("OTLP registry created - endpoint: {}, temporality: {}",
-             config.url(), config.aggregationTemporality());
+    // When a CA-cert path is configured (OTLP_CA_CERT_PATH / OTEL_EXPORTER_OTLP_CERTIFICATE),
+    // route exports through an HTTP sender whose SSLContext additively trusts those CAs so an
+    // internally-signed HTTPS collector validates. Otherwise use the stock registry unchanged.
+    Optional<SSLContext> tls = OtlpTls.sslContextFromEnvironment();
+    OtlpMeterRegistry registry = tls
+        .map(ctx -> OtlpMeterRegistry.builder(config)
+            .metricsSender(new OtlpHttpMetricsSender(
+                OtlpTls.httpSender(ctx, config.connectTimeout(), config.readTimeout())))
+            .build())
+        .orElseGet(() -> new OtlpMeterRegistry(config, Clock.SYSTEM));
+    log.info("OTLP registry created - endpoint: {}, temporality: {}, customCaTrust: {}",
+             config.url(), config.aggregationTemporality(), tls.isPresent());
     return registry;
   }
 

--- a/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
+++ b/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
@@ -50,8 +50,11 @@ public final class OtlpTls {
    * {@link SSLContext}. Custom {@code OTLP_CA_CERT_PATH} takes precedence over the
    * OTLP-spec {@code OTEL_EXPORTER_OTLP_CERTIFICATE}.
    *
-   * @return the context, or empty when no path is configured or it cannot be loaded
-   *     (in which case the exporter falls back to the JVM default trust)
+   * @return the additive-trust context, or empty when no CA-cert path is configured
+   * @throws IllegalStateException when a path is configured but yields no usable certificates
+   *     (missing, empty, or unparseable file). Failing here is deliberate: silently falling
+   *     back to JVM default trust would reproduce the exact PKIX failure this setting exists to
+   *     fix, so a typo or unmounted secret would be indistinguishable from the original error.
    */
   public static Optional<SSLContext> sslContextFromEnvironment() {
     String path = configuredCertPath();
@@ -63,10 +66,10 @@ public final class OtlpTls {
       log.info("OTLP exporter will trust extra CA certificates from {}", path);
       return Optional.of(ctx);
     } catch (Exception e) {
-      // Fail safe: keep the JVM default trust rather than breaking metrics startup.
-      log.error("Failed to load OTLP CA certificates from {} - falling back to JVM default "
-          + "trust; OTLP export to an internally-signed endpoint may fail", path, e);
-      return Optional.empty();
+      throw new IllegalStateException(
+          "OTLP CA cert path '" + path + "' is set but no usable certificates could be loaded "
+          + "(missing, empty, or unparseable PEM); refusing to fall back to JVM default trust",
+          e);
     }
   }
 
@@ -81,8 +84,10 @@ public final class OtlpTls {
 
   /**
    * Builds an {@link SSLContext} whose trust manager combines the JDK default CAs with
-   * the X.509 certificates in {@code pemPath}. An empty file yields a defaults-only
-   * context; invalid content raises the underlying parse exception.
+   * the X.509 certificates in {@code pemPath}. A bundle that yields no certificates (empty
+   * or cert-less file) raises a {@link java.security.cert.CertificateException}, as does
+   * invalid content — so the caller falls back to the stock JVM-default path rather than
+   * reporting custom trust it does not have.
    */
   static SSLContext buildAdditiveContext(Path pemPath) throws Exception {
     SSLContext ctx = SSLContext.getInstance("TLS");
@@ -93,7 +98,10 @@ public final class OtlpTls {
   /**
    * Builds the additive trust manager that backs {@link #buildAdditiveContext}: the JDK
    * default CAs combined with the X.509 certificates in {@code pemPath}. Its accepted
-   * issuers are always a superset of the JDK defaults. Package-private for tests.
+   * issuers are always a strict superset of the JDK defaults. A bundle with no certificates
+   * raises a {@link java.security.cert.CertificateException} rather than silently yielding a
+   * defaults-only manager, so a misconfigured path is never mistaken for added trust.
+   * Package-private for tests.
    */
   static X509TrustManager buildAdditiveTrustManager(Path pemPath) throws Exception {
     List<X509Certificate> extras = new ArrayList<>();
@@ -105,14 +113,14 @@ public final class OtlpTls {
       }
     }
 
+    if (extras.isEmpty()) {
+      throw new java.security.cert.CertificateException(
+          "OTLP CA cert file " + pemPath + " contained no certificates");
+    }
+
     List<X509TrustManager> managers = new ArrayList<>();
     managers.add(defaultTrustManager());
-    if (extras.isEmpty()) {
-      log.warn("OTLP CA cert file {} contained no certificates; using JVM default trust only",
-          pemPath);
-    } else {
-      managers.add(trustManagerFor(extras));
-    }
+    managers.add(trustManagerFor(extras));
     return new CompositeX509TrustManager(managers);
   }
 

--- a/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
+++ b/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
@@ -97,11 +97,11 @@ public final class OtlpTls {
 
   /**
    * Builds the additive trust manager that backs {@link #buildAdditiveContext}: the JDK
-   * default CAs combined with the X.509 certificates in {@code pemPath}. Its accepted
-   * issuers are always a strict superset of the JDK defaults. A bundle with no certificates
-   * raises a {@link java.security.cert.CertificateException} rather than silently yielding a
-   * defaults-only manager, so a misconfigured path is never mistaken for added trust.
-   * Package-private for tests.
+   * default trust anchors merged with the X.509 certificates in {@code pemPath} into a single
+   * PKIX trust manager. Its accepted issuers are always a superset of the JDK defaults, so trust
+   * is only ever widened. A bundle with no certificates raises a
+   * {@link java.security.cert.CertificateException} rather than silently yielding a defaults-only
+   * manager, so a misconfigured path is never mistaken for added trust. Package-private for tests.
    */
   static X509TrustManager buildAdditiveTrustManager(Path pemPath) throws Exception {
     List<X509Certificate> extras = new ArrayList<>();
@@ -118,10 +118,19 @@ public final class OtlpTls {
           "OTLP CA cert file " + pemPath + " contained no certificates");
     }
 
-    List<X509TrustManager> managers = new ArrayList<>();
-    managers.add(defaultTrustManager());
-    managers.add(trustManagerFor(extras));
-    return new CompositeX509TrustManager(managers);
+    // Merge the JDK default trust anchors and the extra CAs into one KeyStore, then build a single
+    // PKIX trust manager over it. That yields a real X509ExtendedTrustManager (endpoint identity
+    // checks intact, no JSSE wrapper), and its trust anchors are a superset of the JDK defaults.
+    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+    ks.load(null, null);
+    int i = 0;
+    for (X509Certificate ca : defaultTrustManager().getAcceptedIssuers()) {
+      ks.setCertificateEntry("default-ca-" + (i++), ca);
+    }
+    for (X509Certificate ca : extras) {
+      ks.setCertificateEntry("otlp-ca-" + (i++), ca);
+    }
+    return firstX509(loadTrustManagerFactory(ks));
   }
 
   /** Returns an {@link HttpSender} backed by the JDK HttpClient using {@code sslContext}. */
@@ -132,16 +141,6 @@ public final class OtlpTls {
 
   private static X509TrustManager defaultTrustManager() throws Exception {
     return firstX509(loadTrustManagerFactory((KeyStore) null));
-  }
-
-  private static X509TrustManager trustManagerFor(List<X509Certificate> certs) throws Exception {
-    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-    ks.load(null, null);
-    int i = 0;
-    for (X509Certificate cert : certs) {
-      ks.setCertificateEntry("otlp-ca-" + (i++), cert);
-    }
-    return firstX509(loadTrustManagerFactory(ks));
   }
 
   private static TrustManagerFactory loadTrustManagerFactory(KeyStore ks) throws Exception {
@@ -158,60 +157,6 @@ public final class OtlpTls {
       }
     }
     throw new IllegalStateException("No X509TrustManager found");
-  }
-
-  /**
-   * Trust manager that accepts a certificate if <em>any</em> delegate accepts it. Delegates
-   * are consulted in order (JDK default first, extra CAs second), so public endpoints keep
-   * validating normally and internally-signed ones validate against the extra CAs.
-   */
-  private static final class CompositeX509TrustManager implements X509TrustManager {
-    private final List<X509TrustManager> delegates;
-
-    CompositeX509TrustManager(List<X509TrustManager> delegates) {
-      this.delegates = delegates;
-    }
-
-    @Override
-    public void checkServerTrusted(X509Certificate[] chain, String authType)
-        throws java.security.cert.CertificateException {
-      java.security.cert.CertificateException last = null;
-      for (X509TrustManager tm : delegates) {
-        try {
-          tm.checkServerTrusted(chain, authType);
-          return;
-        } catch (java.security.cert.CertificateException e) {
-          last = e;
-        }
-      }
-      throw (last != null) ? last : new java.security.cert.CertificateException("No trust managers");
-    }
-
-    @Override
-    public void checkClientTrusted(X509Certificate[] chain, String authType)
-        throws java.security.cert.CertificateException {
-      java.security.cert.CertificateException last = null;
-      for (X509TrustManager tm : delegates) {
-        try {
-          tm.checkClientTrusted(chain, authType);
-          return;
-        } catch (java.security.cert.CertificateException e) {
-          last = e;
-        }
-      }
-      throw (last != null) ? last : new java.security.cert.CertificateException("No trust managers");
-    }
-
-    @Override
-    public X509Certificate[] getAcceptedIssuers() {
-      List<X509Certificate> issuers = new ArrayList<>();
-      for (X509TrustManager tm : delegates) {
-        for (X509Certificate issuer : tm.getAcceptedIssuers()) {
-          issuers.add(issuer);
-        }
-      }
-      return issuers.toArray(new X509Certificate[0]);
-    }
   }
 
   /**

--- a/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
+++ b/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
@@ -1,0 +1,243 @@
+package io.github.themoah.klag.metrics;
+
+import io.micrometer.core.ipc.http.HttpSender;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TLS trust configuration for the OTLP metrics exporter.
+ *
+ * <p>Micrometer's {@code OtlpMeterRegistry} sends over HTTPS using the JVM default
+ * {@link SSLContext}, so a collector served with an internally-signed certificate
+ * (e.g. an in-cluster OpenTelemetry Collector) fails PKIX validation. When
+ * {@code OTLP_CA_CERT_PATH} (or the OTLP-spec {@code OTEL_EXPORTER_OTLP_CERTIFICATE})
+ * points at a PEM bundle, this class builds an {@link SSLContext} that trusts the
+ * JDK's default CAs <em>plus</em> the extra certificates, and exposes an
+ * {@link HttpSender} that uses it. The trust is <strong>additive</strong> and scoped
+ * to the OTLP exporter — it never mutates JVM-global state and can never reduce the
+ * trust the JVM already has.
+ *
+ * <p>The Kafka client is unaffected: kafka-clients builds its own {@code SSLContext}
+ * from {@code ssl.truststore.location} and does not consult this one.
+ */
+public final class OtlpTls {
+
+  private static final Logger log = LoggerFactory.getLogger(OtlpTls.class);
+
+  private OtlpTls() {}
+
+  /**
+   * Reads the configured CA-cert path from the environment and builds an additive-trust
+   * {@link SSLContext}. Custom {@code OTLP_CA_CERT_PATH} takes precedence over the
+   * OTLP-spec {@code OTEL_EXPORTER_OTLP_CERTIFICATE}.
+   *
+   * @return the context, or empty when no path is configured or it cannot be loaded
+   *     (in which case the exporter falls back to the JVM default trust)
+   */
+  public static Optional<SSLContext> sslContextFromEnvironment() {
+    String path = configuredCertPath();
+    if (path == null || path.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      SSLContext ctx = buildAdditiveContext(Path.of(path));
+      log.info("OTLP exporter will trust extra CA certificates from {}", path);
+      return Optional.of(ctx);
+    } catch (Exception e) {
+      // Fail safe: keep the JVM default trust rather than breaking metrics startup.
+      log.error("Failed to load OTLP CA certificates from {} - falling back to JVM default "
+          + "trust; OTLP export to an internally-signed endpoint may fail", path, e);
+      return Optional.empty();
+    }
+  }
+
+  /** Resolves the configured CA-cert path, custom var first, then the OTLP-spec var. */
+  static String configuredCertPath() {
+    String path = System.getenv("OTLP_CA_CERT_PATH");
+    if (path == null || path.isBlank()) {
+      path = System.getenv("OTEL_EXPORTER_OTLP_CERTIFICATE");
+    }
+    return path;
+  }
+
+  /**
+   * Builds an {@link SSLContext} whose trust manager combines the JDK default CAs with
+   * the X.509 certificates in {@code pemPath}. An empty file yields a defaults-only
+   * context; invalid content raises the underlying parse exception.
+   */
+  static SSLContext buildAdditiveContext(Path pemPath) throws Exception {
+    List<X509Certificate> extras = new ArrayList<>();
+    if (Files.size(pemPath) > 0) {
+      try (InputStream in = Files.newInputStream(pemPath)) {
+        for (Certificate cert : CertificateFactory.getInstance("X.509").generateCertificates(in)) {
+          extras.add((X509Certificate) cert);
+        }
+      }
+    }
+
+    List<X509TrustManager> managers = new ArrayList<>();
+    managers.add(defaultTrustManager());
+    if (extras.isEmpty()) {
+      log.warn("OTLP CA cert file {} contained no certificates; using JVM default trust only",
+          pemPath);
+    } else {
+      managers.add(trustManagerFor(extras));
+    }
+
+    SSLContext ctx = SSLContext.getInstance("TLS");
+    ctx.init(null, new TrustManager[] {new CompositeX509TrustManager(managers)}, null);
+    return ctx;
+  }
+
+  /** Returns an {@link HttpSender} backed by the JDK HttpClient using {@code sslContext}. */
+  public static HttpSender httpSender(SSLContext sslContext, Duration connectTimeout,
+      Duration readTimeout) {
+    return new JdkHttpSender(sslContext, connectTimeout, readTimeout);
+  }
+
+  private static X509TrustManager defaultTrustManager() throws Exception {
+    return firstX509(loadTrustManagerFactory((KeyStore) null));
+  }
+
+  private static X509TrustManager trustManagerFor(List<X509Certificate> certs) throws Exception {
+    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+    ks.load(null, null);
+    int i = 0;
+    for (X509Certificate cert : certs) {
+      ks.setCertificateEntry("otlp-ca-" + (i++), cert);
+    }
+    return firstX509(loadTrustManagerFactory(ks));
+  }
+
+  private static TrustManagerFactory loadTrustManagerFactory(KeyStore ks) throws Exception {
+    TrustManagerFactory tmf =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    tmf.init(ks);
+    return tmf;
+  }
+
+  private static X509TrustManager firstX509(TrustManagerFactory tmf) {
+    for (TrustManager tm : tmf.getTrustManagers()) {
+      if (tm instanceof X509TrustManager x509) {
+        return x509;
+      }
+    }
+    throw new IllegalStateException("No X509TrustManager found");
+  }
+
+  /**
+   * Trust manager that accepts a certificate if <em>any</em> delegate accepts it. Delegates
+   * are consulted in order (JDK default first, extra CAs second), so public endpoints keep
+   * validating normally and internally-signed ones validate against the extra CAs.
+   */
+  private static final class CompositeX509TrustManager implements X509TrustManager {
+    private final List<X509TrustManager> delegates;
+
+    CompositeX509TrustManager(List<X509TrustManager> delegates) {
+      this.delegates = delegates;
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType)
+        throws java.security.cert.CertificateException {
+      java.security.cert.CertificateException last = null;
+      for (X509TrustManager tm : delegates) {
+        try {
+          tm.checkServerTrusted(chain, authType);
+          return;
+        } catch (java.security.cert.CertificateException e) {
+          last = e;
+        }
+      }
+      throw (last != null) ? last : new java.security.cert.CertificateException("No trust managers");
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType)
+        throws java.security.cert.CertificateException {
+      java.security.cert.CertificateException last = null;
+      for (X509TrustManager tm : delegates) {
+        try {
+          tm.checkClientTrusted(chain, authType);
+          return;
+        } catch (java.security.cert.CertificateException e) {
+          last = e;
+        }
+      }
+      throw (last != null) ? last : new java.security.cert.CertificateException("No trust managers");
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      List<X509Certificate> issuers = new ArrayList<>();
+      for (X509TrustManager tm : delegates) {
+        for (X509Certificate issuer : tm.getAcceptedIssuers()) {
+          issuers.add(issuer);
+        }
+      }
+      return issuers.toArray(new X509Certificate[0]);
+    }
+  }
+
+  /**
+   * Minimal {@link HttpSender} over {@link HttpClient}. Micrometer's stock
+   * {@code HttpUrlConnectionSender} has no per-connection SSL hook, so a custom sender is
+   * the only way to scope a non-default {@link SSLContext} to the OTLP exporter.
+   */
+  private static final class JdkHttpSender implements HttpSender {
+    private final HttpClient client;
+    private final Duration readTimeout;
+
+    JdkHttpSender(SSLContext sslContext, Duration connectTimeout, Duration readTimeout) {
+      this.client = HttpClient.newBuilder()
+          .sslContext(sslContext)
+          .connectTimeout(connectTimeout)
+          .build();
+      this.readTimeout = readTimeout;
+    }
+
+    @Override
+    public Response send(Request request) throws Throwable {
+      byte[] entity = request.getEntity();
+      HttpRequest.BodyPublisher body = (entity != null && entity.length > 0)
+          ? HttpRequest.BodyPublishers.ofByteArray(entity)
+          : HttpRequest.BodyPublishers.noBody();
+
+      HttpRequest.Builder builder = HttpRequest.newBuilder(request.getUrl().toURI())
+          .timeout(readTimeout)
+          .method(request.getMethod().name(), body);
+
+      for (Map.Entry<String, String> header : request.getRequestHeaders().entrySet()) {
+        try {
+          builder.header(header.getKey(), header.getValue());
+        } catch (IllegalArgumentException restricted) {
+          // HttpClient forbids setting a few headers (e.g. Content-Length); it sets them itself.
+          log.debug("Skipping restricted request header {}", header.getKey());
+        }
+      }
+
+      HttpResponse<String> response =
+          client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+      return new Response(response.statusCode(), response.body());
+    }
+  }
+}

--- a/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
+++ b/src/main/java/io/github/themoah/klag/metrics/OtlpTls.java
@@ -85,6 +85,17 @@ public final class OtlpTls {
    * context; invalid content raises the underlying parse exception.
    */
   static SSLContext buildAdditiveContext(Path pemPath) throws Exception {
+    SSLContext ctx = SSLContext.getInstance("TLS");
+    ctx.init(null, new TrustManager[] {buildAdditiveTrustManager(pemPath)}, null);
+    return ctx;
+  }
+
+  /**
+   * Builds the additive trust manager that backs {@link #buildAdditiveContext}: the JDK
+   * default CAs combined with the X.509 certificates in {@code pemPath}. Its accepted
+   * issuers are always a superset of the JDK defaults. Package-private for tests.
+   */
+  static X509TrustManager buildAdditiveTrustManager(Path pemPath) throws Exception {
     List<X509Certificate> extras = new ArrayList<>();
     if (Files.size(pemPath) > 0) {
       try (InputStream in = Files.newInputStream(pemPath)) {
@@ -102,10 +113,7 @@ public final class OtlpTls {
     } else {
       managers.add(trustManagerFor(extras));
     }
-
-    SSLContext ctx = SSLContext.getInstance("TLS");
-    ctx.init(null, new TrustManager[] {new CompositeX509TrustManager(managers)}, null);
-    return ctx;
+    return new CompositeX509TrustManager(managers);
   }
 
   /** Returns an {@link HttpSender} backed by the JDK HttpClient using {@code sslContext}. */
@@ -211,6 +219,9 @@ public final class OtlpTls {
       this.client = HttpClient.newBuilder()
           .sslContext(sslContext)
           .connectTimeout(connectTimeout)
+          // Match Micrometer's stock HttpUrlConnectionSender, which follows same-protocol
+          // redirects; HttpClient otherwise defaults to Redirect.NEVER.
+          .followRedirects(HttpClient.Redirect.NORMAL)
           .build();
       this.readTimeout = readTimeout;
     }

--- a/src/test/java/io/github/themoah/klag/metrics/OtlpHttpSenderTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/OtlpHttpSenderTest.java
@@ -1,0 +1,108 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.micrometer.core.ipc.http.HttpSender;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the JDK-{@code HttpClient}-backed {@link HttpSender} that {@link OtlpTls#httpSender}
+ * returns. Uses an in-process {@link HttpServer}: plain HTTP is enough to exercise the sender's new
+ * risk surface — header forwarding, redirect following, and status/body response mapping. The
+ * {@link SSLContext} wiring is covered by the additive-trust unit tests in {@link OtlpTlsTest}.
+ */
+class OtlpHttpSenderTest {
+
+  private HttpServer server;
+  private String baseUrl;
+
+  @BeforeEach
+  void startServer() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.start();
+    baseUrl = "http://localhost:" + server.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stopServer() {
+    server.stop(0);
+  }
+
+  private HttpSender sender() throws Exception {
+    return OtlpTls.httpSender(SSLContext.getDefault(), Duration.ofSeconds(2), Duration.ofSeconds(5));
+  }
+
+  private static void respond(HttpExchange ex, int code, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    ex.sendResponseHeaders(code, bytes.length);
+    try (OutputStream os = ex.getResponseBody()) {
+      os.write(bytes);
+    }
+  }
+
+  @Test
+  void forwardsHeadersAndBody_andMapsSuccessResponse() throws Throwable {
+    AtomicReference<String> seenHeader = new AtomicReference<>();
+    AtomicReference<String> seenContentType = new AtomicReference<>();
+    AtomicReference<Integer> seenBodyLen = new AtomicReference<>();
+    server.createContext("/v1/metrics", ex -> {
+      seenHeader.set(ex.getRequestHeaders().getFirst("X-Klag-Test"));
+      seenContentType.set(ex.getRequestHeaders().getFirst("Content-Type"));
+      seenBodyLen.set(ex.getRequestBody().readAllBytes().length);
+      respond(ex, 200, "ok");
+    });
+
+    HttpSender.Response resp = sender().post(baseUrl + "/v1/metrics")
+        .withHeader("X-Klag-Test", "klag")
+        .withContent("application/x-protobuf", new byte[] {1, 2, 3, 4})
+        .send();
+
+    assertEquals(200, resp.code());
+    assertEquals("ok", resp.body());
+    assertEquals("klag", seenHeader.get(), "custom request header was not forwarded");
+    assertEquals("application/x-protobuf", seenContentType.get(), "content type was not forwarded");
+    assertEquals(4, seenBodyLen.get(), "request body was not forwarded intact");
+  }
+
+  @Test
+  void followsRedirect() throws Throwable {
+    server.createContext("/redirect", ex -> {
+      ex.getResponseHeaders().set("Location", baseUrl + "/final");
+      ex.sendResponseHeaders(302, -1);
+      ex.close();
+    });
+    server.createContext("/final", ex -> respond(ex, 200, "landed"));
+
+    HttpSender.Response resp = sender().post(baseUrl + "/redirect")
+        .withContent("application/x-protobuf", new byte[] {1})
+        .send();
+
+    assertEquals(200, resp.code(), "sender should follow the 302 to the final endpoint");
+    assertEquals("landed", resp.body());
+  }
+
+  @Test
+  void mapsErrorResponse() throws Throwable {
+    server.createContext("/err", ex -> respond(ex, 503, "busy"));
+
+    HttpSender.Response resp = sender().post(baseUrl + "/err")
+        .withContent("application/x-protobuf", new byte[] {1})
+        .send();
+
+    assertEquals(503, resp.code());
+    assertEquals("busy", resp.body());
+    assertFalse(resp.isSuccessful(), "5xx should not map to a successful response");
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
@@ -8,7 +8,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -19,8 +24,9 @@ import org.junit.jupiter.api.io.TempDir;
  * Unit tests for {@link OtlpTls}.
  *
  * <p>Env-var stubbing is intentionally avoided (no portable JVM API); the loader is exercised
- * directly via {@link OtlpTls#buildAdditiveContext}. Certificate fixtures are real CAs exported
- * from the running JDK's default trust store, so the tests run anywhere a JDK is installed.
+ * directly via {@link OtlpTls#buildAdditiveContext} / {@link OtlpTls#buildAdditiveTrustManager}.
+ * Certificate fixtures are real CAs exported from the running JDK's default trust store, so the
+ * tests run anywhere a JDK is installed.
  */
 class OtlpTlsTest {
 
@@ -39,23 +45,30 @@ class OtlpTlsTest {
     throw new IllegalStateException("no default X509TrustManager");
   }
 
-  private static String toPem(java.security.cert.X509Certificate cert) throws Exception {
+  private static String toPem(X509Certificate cert) throws Exception {
     String body = Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(cert.getEncoded());
     return "-----BEGIN CERTIFICATE-----\n" + body + "\n-----END CERTIFICATE-----\n";
   }
 
   @Test
-  void additiveContext_trustsDefaultsPlusExtraCerts() throws Exception {
-    var defaultIssuers = defaultTrustManager().getAcceptedIssuers();
-    assumeTrue(defaultIssuers.length >= 2, "JDK trust store has too few CAs for this test");
+  void additiveTrust_acceptedIssuersAreSupersetOfDefaults() throws Exception {
+    X509Certificate[] defaults = defaultTrustManager().getAcceptedIssuers();
+    assumeTrue(defaults.length >= 2, "JDK trust store has too few CAs for this test");
 
-    // Use two real CAs as the "extra" bundle so we exercise the multi-cert path.
-    Path pem = tmp.resolve("ca-bundle.pem");
-    Files.writeString(pem, toPem(defaultIssuers[0]) + toPem(defaultIssuers[1]));
+    // A single JDK CA used as the "extra" bundle: whatever the defaults are, the composite must
+    // still accept every one of them AND carry at least one more accepted issuer than defaults —
+    // so dropping the extras (a regression) would be detectable.
+    Path pem = tmp.resolve("ca.pem");
+    Files.writeString(pem, toPem(defaults[0]));
 
-    SSLContext ctx = OtlpTls.buildAdditiveContext(pem);
-    assertNotNull(ctx);
-    assertNotNull(ctx.getSocketFactory());
+    X509Certificate[] combined = OtlpTls.buildAdditiveTrustManager(pem).getAcceptedIssuers();
+
+    Set<X509Certificate> combinedSet = new HashSet<>(Arrays.asList(combined));
+    for (X509Certificate def : defaults) {
+      assertTrue(combinedSet.contains(def), "composite dropped a JDK default issuer");
+    }
+    assertTrue(combined.length > defaults.length,
+        "composite should add the extra CA on top of the defaults");
   }
 
   @Test
@@ -65,29 +78,36 @@ class OtlpTlsTest {
 
     SSLContext ctx = OtlpTls.buildAdditiveContext(pem);
 
-    // Trust is never reduced: an empty bundle still yields a usable defaults-only context.
+    // Trust is never reduced: an empty bundle still yields a usable defaults-only context whose
+    // accepted issuers match the JDK defaults exactly.
     assertNotNull(ctx);
     assertNotNull(ctx.getSocketFactory());
+    assertTrue(OtlpTls.buildAdditiveTrustManager(pem).getAcceptedIssuers().length
+        == defaultTrustManager().getAcceptedIssuers().length);
   }
 
   @Test
-  void additiveContext_invalidContent_throws() {
+  void additiveContext_invalidContent_throws() throws Exception {
     Path pem = tmp.resolve("garbage.pem");
-    assertThrows(Exception.class, () -> {
-      Files.writeString(pem, "this is not a certificate");
-      OtlpTls.buildAdditiveContext(pem);
-    });
+    Files.writeString(pem, "this is not a certificate");
+    assertThrows(CertificateException.class, () -> OtlpTls.buildAdditiveContext(pem));
   }
 
   @Test
   void configuredCertPath_unset_isNullOrBlank() {
-    // Neither env var is expected in the test JVM; loader should treat that as "no custom trust".
+    // Guard: only meaningful when the test JVM has neither cert env var set.
+    assumeTrue(System.getenv("OTLP_CA_CERT_PATH") == null
+        && System.getenv("OTEL_EXPORTER_OTLP_CERTIFICATE") == null,
+        "cert-path env var set in this environment");
     String path = OtlpTls.configuredCertPath();
     assertTrue(path == null || path.isBlank(), "expected no configured cert path in test env");
   }
 
   @Test
   void sslContextFromEnvironment_unset_isEmpty() {
+    assumeTrue(System.getenv("OTLP_CA_CERT_PATH") == null
+        && System.getenv("OTEL_EXPORTER_OTLP_CERTIFICATE") == null,
+        "cert-path env var set in this environment");
     assertTrue(OtlpTls.sslContextFromEnvironment().isEmpty());
   }
 }

--- a/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
@@ -1,6 +1,5 @@
 package io.github.themoah.klag.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -14,7 +13,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import org.junit.jupiter.api.Test;
@@ -72,18 +70,14 @@ class OtlpTlsTest {
   }
 
   @Test
-  void additiveContext_emptyFile_yieldsDefaultsOnlyContext() throws Exception {
+  void additiveContext_emptyFile_throws() throws Exception {
     Path pem = tmp.resolve("empty.pem");
     Files.writeString(pem, "");
 
-    SSLContext ctx = OtlpTls.buildAdditiveContext(pem);
-
-    // Trust is never reduced: an empty bundle still yields a usable defaults-only context whose
-    // accepted issuers match the JDK defaults exactly.
-    assertNotNull(ctx);
-    assertNotNull(ctx.getSocketFactory());
-    assertTrue(OtlpTls.buildAdditiveTrustManager(pem).getAcceptedIssuers().length
-        == defaultTrustManager().getAcceptedIssuers().length);
+    // A configured-but-cert-less bundle is a misconfiguration: rather than silently yield a
+    // defaults-only context (which would log customCaTrust: true while trusting nothing extra),
+    // it throws so the caller falls back to the stock JVM-default exporter path.
+    assertThrows(CertificateException.class, () -> OtlpTls.buildAdditiveContext(pem));
   }
 
   @Test

--- a/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
@@ -49,13 +49,14 @@ class OtlpTlsTest {
   }
 
   @Test
-  void additiveTrust_acceptedIssuersAreSupersetOfDefaults() throws Exception {
+  void additiveTrust_neverReducesDefaultIssuers() throws Exception {
     X509Certificate[] defaults = defaultTrustManager().getAcceptedIssuers();
-    assumeTrue(defaults.length >= 2, "JDK trust store has too few CAs for this test");
+    assumeTrue(defaults.length >= 1, "JDK trust store has no CAs for this test");
 
-    // A single JDK CA used as the "extra" bundle: whatever the defaults are, the composite must
-    // still accept every one of them AND carry at least one more accepted issuer than defaults —
-    // so dropping the extras (a regression) would be detectable.
+    // Feed one real JDK CA back in as the "extra" bundle (guaranteed parseable, runs anywhere).
+    // The single merged PKIX KeyStore de-dupes trust anchors, so an extra that duplicates a
+    // default does not grow the count — the invariant that matters is that trust is never
+    // narrowed: every JDK default issuer must still be accepted after the merge.
     Path pem = tmp.resolve("ca.pem");
     Files.writeString(pem, toPem(defaults[0]));
 
@@ -63,10 +64,8 @@ class OtlpTlsTest {
 
     Set<X509Certificate> combinedSet = new HashSet<>(Arrays.asList(combined));
     for (X509Certificate def : defaults) {
-      assertTrue(combinedSet.contains(def), "composite dropped a JDK default issuer");
+      assertTrue(combinedSet.contains(def), "additive trust dropped a JDK default issuer");
     }
-    assertTrue(combined.length > defaults.length,
-        "composite should add the extra CA on top of the defaults");
   }
 
   @Test

--- a/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/OtlpTlsTest.java
@@ -1,0 +1,93 @@
+package io.github.themoah.klag.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Base64;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link OtlpTls}.
+ *
+ * <p>Env-var stubbing is intentionally avoided (no portable JVM API); the loader is exercised
+ * directly via {@link OtlpTls#buildAdditiveContext}. Certificate fixtures are real CAs exported
+ * from the running JDK's default trust store, so the tests run anywhere a JDK is installed.
+ */
+class OtlpTlsTest {
+
+  @TempDir
+  Path tmp;
+
+  private static X509TrustManager defaultTrustManager() throws Exception {
+    TrustManagerFactory tmf =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    tmf.init((KeyStore) null);
+    for (var tm : tmf.getTrustManagers()) {
+      if (tm instanceof X509TrustManager x509) {
+        return x509;
+      }
+    }
+    throw new IllegalStateException("no default X509TrustManager");
+  }
+
+  private static String toPem(java.security.cert.X509Certificate cert) throws Exception {
+    String body = Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(cert.getEncoded());
+    return "-----BEGIN CERTIFICATE-----\n" + body + "\n-----END CERTIFICATE-----\n";
+  }
+
+  @Test
+  void additiveContext_trustsDefaultsPlusExtraCerts() throws Exception {
+    var defaultIssuers = defaultTrustManager().getAcceptedIssuers();
+    assumeTrue(defaultIssuers.length >= 2, "JDK trust store has too few CAs for this test");
+
+    // Use two real CAs as the "extra" bundle so we exercise the multi-cert path.
+    Path pem = tmp.resolve("ca-bundle.pem");
+    Files.writeString(pem, toPem(defaultIssuers[0]) + toPem(defaultIssuers[1]));
+
+    SSLContext ctx = OtlpTls.buildAdditiveContext(pem);
+    assertNotNull(ctx);
+    assertNotNull(ctx.getSocketFactory());
+  }
+
+  @Test
+  void additiveContext_emptyFile_yieldsDefaultsOnlyContext() throws Exception {
+    Path pem = tmp.resolve("empty.pem");
+    Files.writeString(pem, "");
+
+    SSLContext ctx = OtlpTls.buildAdditiveContext(pem);
+
+    // Trust is never reduced: an empty bundle still yields a usable defaults-only context.
+    assertNotNull(ctx);
+    assertNotNull(ctx.getSocketFactory());
+  }
+
+  @Test
+  void additiveContext_invalidContent_throws() {
+    Path pem = tmp.resolve("garbage.pem");
+    assertThrows(Exception.class, () -> {
+      Files.writeString(pem, "this is not a certificate");
+      OtlpTls.buildAdditiveContext(pem);
+    });
+  }
+
+  @Test
+  void configuredCertPath_unset_isNullOrBlank() {
+    // Neither env var is expected in the test JVM; loader should treat that as "no custom trust".
+    String path = OtlpTls.configuredCertPath();
+    assertTrue(path == null || path.isBlank(), "expected no configured cert path in test env");
+  }
+
+  @Test
+  void sslContextFromEnvironment_unset_isEmpty() {
+    assertTrue(OtlpTls.sslContextFromEnvironment().isEmpty());
+  }
+}

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -138,11 +138,19 @@ These are environment-only. See [Datadog](/integrations/datadog/).
 | `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes. |
 | `OTEL_EXPORTER_OTLP_CERTIFICATE` | Path to a PEM CA bundle the exporter additionally trusts (for an HTTPS collector with an internally-signed cert). Added on top of the JVM default trust, never replacing it. |
 
-**Custom variables (override `OTEL_*`):** `OTLP_ENDPOINT`, `OTLP_STEP_MS`,
-`OTLP_HEADERS`, `OTLP_RESOURCE_ATTRIBUTES`, `OTLP_CA_CERT_PATH` (alias for
-`OTEL_EXPORTER_OTLP_CERTIFICATE`). Transport is HTTP/protobuf (port 4318); both
-`http://` and `https://` endpoints are supported — for an internally-signed HTTPS
-collector, point `OTLP_CA_CERT_PATH` at the CA bundle. Temporality is cumulative.
+**Custom variables** — each takes precedence over its `OTEL_*` equivalent:
+
+| Variable | Overrides | Description |
+|---|---|---|
+| `OTLP_ENDPOINT` | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, `OTEL_EXPORTER_OTLP_ENDPOINT` | Full metrics endpoint URL (e.g. `http://localhost:4318/v1/metrics`). |
+| `OTLP_STEP_MS` | `OTEL_METRIC_EXPORT_INTERVAL` | Export interval in ms (default `60000`). |
+| `OTLP_HEADERS` | `OTEL_EXPORTER_OTLP_METRICS_HEADERS`, `OTEL_EXPORTER_OTLP_HEADERS` | Auth headers (`key1=value1,key2=value2`). |
+| `OTLP_RESOURCE_ATTRIBUTES` | `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes (`key1=value1,key2=value2`). |
+| `OTLP_CA_CERT_PATH` | `OTEL_EXPORTER_OTLP_CERTIFICATE` | Path to a PEM CA bundle the exporter additionally trusts, for an HTTPS collector with an internally-signed cert. Added on top of the JVM default trust, never replacing it. |
+
+Transport is HTTP/protobuf (port 4318); both `http://` and `https://` endpoints are
+supported — for an internally-signed HTTPS collector, point `OTLP_CA_CERT_PATH` (or
+`OTEL_EXPORTER_OTLP_CERTIFICATE`) at the CA bundle. Temporality is cumulative.
 See [OTLP & Grafana Cloud](/integrations/otlp-grafana/).
 
 ## Logging

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -136,10 +136,14 @@ These are environment-only. See [Datadog](/integrations/datadog/).
 | `OTEL_METRIC_EXPORT_INTERVAL` | Export interval (ms), default `60000`. |
 | `OTEL_SERVICE_NAME` | Service name, default `klag`. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes. |
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` | Path to a PEM CA bundle the exporter additionally trusts (for an HTTPS collector with an internally-signed cert). Added on top of the JVM default trust, never replacing it. |
 
 **Custom variables (override `OTEL_*`):** `OTLP_ENDPOINT`, `OTLP_STEP_MS`,
-`OTLP_HEADERS`, `OTLP_RESOURCE_ATTRIBUTES`. Protocol is HTTP only (port 4318);
-temporality is cumulative. See [OTLP & Grafana Cloud](/integrations/otlp-grafana/).
+`OTLP_HEADERS`, `OTLP_RESOURCE_ATTRIBUTES`, `OTLP_CA_CERT_PATH` (alias for
+`OTEL_EXPORTER_OTLP_CERTIFICATE`). Transport is HTTP/protobuf (port 4318); both
+`http://` and `https://` endpoints are supported — for an internally-signed HTTPS
+collector, point `OTLP_CA_CERT_PATH` at the CA bundle. Temporality is cumulative.
+See [OTLP & Grafana Cloud](/integrations/otlp-grafana/).
 
 ## Logging
 


### PR DESCRIPTION
## Summary

Micrometer's `OtlpMeterRegistry` sends over HTTPS using the JVM **default** `SSLContext`, so a collector served with an **internally-signed certificate** (e.g. an in-cluster OpenTelemetry Collector) fails PKIX validation and metrics never ship:

```
i.m.registry.otlp.OtlpMeterRegistry - Failed to publish metrics to OTLP receiver
javax.net.ssl.SSLHandshakeException: PKIX path building failed: ... unable to find valid certification path to requested target
```

This adds an opt-in way to trust extra CA certificates for the OTLP exporter, so klag can ship to an HTTPS collector like a standards-compliant OTLP client instead of being restricted to plaintext.

## What changed

- **`OTLP_CA_CERT_PATH`** — alias for the OTLP-spec **`OTEL_EXPORTER_OTLP_CERTIFICATE`** (custom var wins, matching the existing `OTLP_*` precedence). When set, the PEM bundle is parsed and installed as an **additive** trust manager: JDK defaults first, extra CAs second. Trust is only ever widened, never reduced.
- The SSLContext is **scoped to the OTLP exporter** via the Micrometer 1.16 registry builder + a small `HttpSender` over the JDK `HttpClient` — no `SSLContext.setDefault(...)`, no JVM-global mutation. The Kafka client builds its own `SSLContext` from `ssl.truststore.location` and is unaffected.
- **Unset ⇒ unchanged behaviour** — the stock `new OtlpMeterRegistry(config, Clock.SYSTEM)` path with JVM default trust.

### Chart
- `metrics.otlp.caCertPath` renders `OTLP_CA_CERT_PATH`. Mount the bundle with the existing `extraVolumes`/`extraVolumeMounts`.

```yaml
metrics:
  reporter: otlp
  otlp:
    endpoint: "https://otel-collector.observability.svc:4318/v1/metrics"
    caCertPath: "/etc/otel-certs/ca.crt"
extraVolumes:
  - name: otel-ca
    secret:
      secretName: otel-collector-ca
extraVolumeMounts:
  - name: otel-ca
    mountPath: /etc/otel-certs
    readOnly: true
```

## Why this shape (and not a global additive trust)

The clean fix — scoping a custom `SSLContext` to the OTLP registry — needs the registry builder / custom sender that only lands on Micrometer 1.15+. The repo is now on **1.16.6**, so this is done properly: the trust widening is naturally scoped to the OTLP exporter (klag has no other outbound HTTPS client, and kafka-clients does not consult `SSLContext.getDefault()`), with no JVM-global side effects.

## Tests

- `OtlpTlsTest` — additive trust from a real multi-cert PEM, empty-file (defaults-only) and invalid-content behaviour, and unset-env no-op. Fixtures are CAs exported from the running JDK's trust store, so they run anywhere.
- `scripts/test-helm-chart.sh` — `OTLP_CA_CERT_PATH` present when `caCertPath` is set, absent by default (39/39 pass).
- Full `gradle test` green.

## Versions

Bumped together so the chart is releasable and passes `check-version-consistency.sh`:
- app `build.gradle.kts` `0.2.14 → 0.2.15`
- chart `appVersion` `0.2.14 → 0.2.15`, chart `version` `0.3.9 → 0.3.10`

Happy to drop or adjust the version bumps if you'd rather handle them as part of your release flow.

## Out of scope

gRPC OTLP, delta temporality, and client-certificate (mTLS) auth — server-CA trust only.

## Summary by Sourcery

Enable scoped, additive CA trust for OTLP HTTPS metric exports without changing JVM-wide or Kafka TLS behavior.

New Features:
- Allow the OTLP exporter to trust additional PEM CA certificates for HTTPS collectors through OTLP_CA_CERT_PATH or OTEL_EXPORTER_OTLP_CERTIFICATE.
- Expose the OTLP CA certificate path through Helm configuration and deployment environment variables.

Enhancements:
- Scope custom CA trust to the OTLP exporter while preserving JVM default trust and leaving Kafka TLS unaffected.
- Support HTTPS OTLP endpoints alongside existing HTTP endpoints and fail fast for unusable configured CA bundles.

Build:
- Bump the application and Helm chart versions for the releasable change.

Documentation:
- Document the new OTLP certificate environment variables, HTTPS support, and Helm configuration.

Tests:
- Add coverage for additive trust behavior, invalid and empty certificate bundles, HTTP sender behavior, and Helm rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom CA certificate support for HTTPS OTLP collectors.
  * Added `metrics.otlp.caCertPath` configuration for Helm deployments.
  * Added service monitor metric relabeling options.

* **Bug Fixes**
  * Invalid certificate configurations now fail fast.
  * Improved cleanup of metrics for deleted topics.
  * Improved MCP snapshot refreshes after partial processing cycles.

* **Security**
  * Updated Micrometer to address a security issue.

* **Documentation**
  * Updated OTLP and Helm documentation with certificate and HTTPS configuration details.

* **Chores**
  * Bumped the application and Helm chart versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->