### PR TITLE
feat: add ServiceMonitor metricRelabelings and relabelings Helm values

### DIFF
--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.9
+version: 0.3.10
 appVersion: "0.2.14"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
@@ -34,6 +34,8 @@ annotations:
     - name: themoah
       email: aviv@dozorets.com
   artifacthub.io/changes: |
+    - kind: added
+      description: Expose serviceMonitor.metricRelabelings and serviceMonitor.relabelings so Prometheus Operator can rewrite labels without a second ServiceMonitor or a chart fork
     - kind: security
       description: Upgrade Micrometer to 1.16.6 (CVE-2026-40984 in micrometer-core; the 1.12 line is EOL and unpatched), which moves the Prometheus registry onto the Prometheus Java client 1.x and drops the EOL io.prometheus:simpleclient jars; scraped metric names, labels and values are unchanged
     - kind: changed

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -93,6 +93,16 @@ helm install klag ./charts/klag \
   --set serviceMonitor.enabled=true
 ```
 
+Drop high-cardinality member labels (or mint extra labels) with `serviceMonitor.metricRelabelings`:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  metricRelabelings:
+    - action: labeldrop
+      regex: ^(member_host|consumer_id|client_id)$
+```
+
 ## Configuration
 
 ### General Parameters
@@ -200,6 +210,8 @@ Set `KLAG_CONFIG_FILE` to the path of an external `application.properties` (typi
 | `serviceMonitor.interval` | Scrape interval | `30s` |
 | `serviceMonitor.scrapeTimeout` | Scrape timeout | `10s` |
 | `serviceMonitor.labels` | Additional labels | `{}` |
+| `serviceMonitor.metricRelabelings` | Prometheus `metric_relabel_configs` (post-scrape). Omitted when empty | `[]` |
+| `serviceMonitor.relabelings` | Prometheus `relabel_configs` (pre-scrape). Omitted when empty | `[]` |
 
 ### Pod Configuration
 

--- a/charts/klag/README.md
+++ b/charts/klag/README.md
@@ -103,6 +103,9 @@ serviceMonitor:
       regex: ^(member_host|consumer_id|client_id)$
 ```
 
+`labeldrop` on those names overlaps `CONSUMER_MEMBER_LABELS_ENABLED=false`, which is
+cheaper — Klag never builds the series.
+
 ## Configuration
 
 ### General Parameters

--- a/charts/klag/templates/servicemonitor.yaml
+++ b/charts/klag/templates/servicemonitor.yaml
@@ -23,6 +23,14 @@ spec:
       path: /metrics
       interval: {{ .Values.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/klag/tests/test-values.yaml
+++ b/charts/klag/tests/test-values.yaml
@@ -11,3 +11,10 @@ metrics:
 
 serviceMonitor:
   enabled: true
+  metricRelabelings:
+    - action: labeldrop
+      regex: ^(member_host|consumer_id|client_id)$
+  relabelings:
+    - action: replace
+      targetLabel: cluster
+      replacement: test

--- a/charts/klag/values.yaml
+++ b/charts/klag/values.yaml
@@ -251,3 +251,11 @@ serviceMonitor:
   scrapeTimeout: 10s
   # Additional labels for the ServiceMonitor
   labels: {}
+  # Prometheus metric_relabel_configs applied after scrape (drop labels, mint
+  # extra labels from existing ones). Empty = omit the field.
+  # Example:
+  # - action: labeldrop
+  #   regex: ^(member_host|consumer_id|client_id)$
+  metricRelabelings: []
+  # Prometheus relabel_configs applied to the scrape target before scrape.
+  relabelings: []

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -69,45 +69,6 @@ validate_not_present() {
     fi
 }
 
-# Slice the ServiceMonitor document from a multi-doc helm template render.
-servicemonitor_doc() {
-    local values_file="$1"
-    local extra_args="${2:-}"
-    helm template test-release "${CHART_DIR}" ${values_file:+-f "$values_file"} ${extra_args} 2>/dev/null \
-        | awk 'BEGIN { RS="---" } /kind: ServiceMonitor/ { print; exit }'
-}
-
-# Assert relabel fields sit on the ServiceMonitor scrape endpoint (6-space keys
-# under spec.endpoints[0]), not merely somewhere in the chart output.
-validate_servicemonitor_endpoint_relabelings() {
-    local test_name="$1"
-    local values_file="$2"
-
-    echo -n "Validating: ${test_name}... "
-
-    local sm
-    sm="$(servicemonitor_doc "$values_file")"
-    if [ -z "$sm" ]; then
-        echo -e "${RED}FAILED${NC}"
-        echo "  No ServiceMonitor document in helm output"
-        ((failed++))
-        return
-    fi
-
-    if echo "$sm" | grep -qE '^      metricRelabelings:' \
-        && echo "$sm" | grep -qE '^        - action: labeldrop' \
-        && echo "$sm" | grep -qE '^      relabelings:' \
-        && echo "$sm" | grep -qE '^          targetLabel: cluster'; then
-        echo -e "${GREEN}PASSED${NC}"
-        ((passed++))
-    else
-        echo -e "${RED}FAILED${NC}"
-        echo "  Expected metricRelabelings/relabelings under spec.endpoints[0]"
-        echo "$sm" | sed 's/^/  /'
-        ((failed++))
-    fi
-}
-
 echo "--- Chart Linting ---"
 echo -n "Linting chart... "
 if helm lint "${CHART_DIR}" > /dev/null 2>&1; then
@@ -170,7 +131,8 @@ validate_output "Datadog secret created" "${TESTS_DIR}/test-values-datadog.yaml"
 # ServiceMonitor validation
 validate_output "ServiceMonitor created" "${TESTS_DIR}/test-values.yaml" "kind: ServiceMonitor"
 validate_output "ServiceMonitor scrapes /metrics" "${TESTS_DIR}/test-values.yaml" "path: /metrics"
-validate_servicemonitor_endpoint_relabelings "ServiceMonitor endpoint relabelings" "${TESTS_DIR}/test-values.yaml"
+validate_output "ServiceMonitor metricRelabelings on endpoint" "${TESTS_DIR}/test-values.yaml" '^      metricRelabelings:'
+validate_output "ServiceMonitor relabelings on endpoint"       "${TESTS_DIR}/test-values.yaml" '^      relabelings:'
 validate_not_present "No ServiceMonitor by default" "" "kind: ServiceMonitor"
 validate_not_present "No metricRelabelings when unset" "" "metricRelabelings" "--set serviceMonitor.enabled=true"
 

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -69,6 +69,45 @@ validate_not_present() {
     fi
 }
 
+# Slice the ServiceMonitor document from a multi-doc helm template render.
+servicemonitor_doc() {
+    local values_file="$1"
+    local extra_args="${2:-}"
+    helm template test-release "${CHART_DIR}" ${values_file:+-f "$values_file"} ${extra_args} 2>/dev/null \
+        | awk 'BEGIN { RS="---" } /kind: ServiceMonitor/ { print; exit }'
+}
+
+# Assert relabel fields sit on the ServiceMonitor scrape endpoint (6-space keys
+# under spec.endpoints[0]), not merely somewhere in the chart output.
+validate_servicemonitor_endpoint_relabelings() {
+    local test_name="$1"
+    local values_file="$2"
+
+    echo -n "Validating: ${test_name}... "
+
+    local sm
+    sm="$(servicemonitor_doc "$values_file")"
+    if [ -z "$sm" ]; then
+        echo -e "${RED}FAILED${NC}"
+        echo "  No ServiceMonitor document in helm output"
+        ((failed++))
+        return
+    fi
+
+    if echo "$sm" | grep -qE '^      metricRelabelings:' \
+        && echo "$sm" | grep -qE '^        - action: labeldrop' \
+        && echo "$sm" | grep -qE '^      relabelings:' \
+        && echo "$sm" | grep -qE '^          targetLabel: cluster'; then
+        echo -e "${GREEN}PASSED${NC}"
+        ((passed++))
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo "  Expected metricRelabelings/relabelings under spec.endpoints[0]"
+        echo "$sm" | sed 's/^/  /'
+        ((failed++))
+    fi
+}
+
 echo "--- Chart Linting ---"
 echo -n "Linting chart... "
 if helm lint "${CHART_DIR}" > /dev/null 2>&1; then
@@ -131,9 +170,7 @@ validate_output "Datadog secret created" "${TESTS_DIR}/test-values-datadog.yaml"
 # ServiceMonitor validation
 validate_output "ServiceMonitor created" "${TESTS_DIR}/test-values.yaml" "kind: ServiceMonitor"
 validate_output "ServiceMonitor scrapes /metrics" "${TESTS_DIR}/test-values.yaml" "path: /metrics"
-validate_output "ServiceMonitor metricRelabelings" "${TESTS_DIR}/test-values.yaml" "metricRelabelings"
-validate_output "ServiceMonitor labeldrop" "${TESTS_DIR}/test-values.yaml" "action: labeldrop"
-validate_output "ServiceMonitor relabelings" "${TESTS_DIR}/test-values.yaml" "targetLabel: cluster"
+validate_servicemonitor_endpoint_relabelings "ServiceMonitor endpoint relabelings" "${TESTS_DIR}/test-values.yaml"
 validate_not_present "No ServiceMonitor by default" "" "kind: ServiceMonitor"
 validate_not_present "No metricRelabelings when unset" "" "metricRelabelings" "--set serviceMonitor.enabled=true"
 

--- a/scripts/test-helm-chart.sh
+++ b/scripts/test-helm-chart.sh
@@ -131,7 +131,11 @@ validate_output "Datadog secret created" "${TESTS_DIR}/test-values-datadog.yaml"
 # ServiceMonitor validation
 validate_output "ServiceMonitor created" "${TESTS_DIR}/test-values.yaml" "kind: ServiceMonitor"
 validate_output "ServiceMonitor scrapes /metrics" "${TESTS_DIR}/test-values.yaml" "path: /metrics"
+validate_output "ServiceMonitor metricRelabelings" "${TESTS_DIR}/test-values.yaml" "metricRelabelings"
+validate_output "ServiceMonitor labeldrop" "${TESTS_DIR}/test-values.yaml" "action: labeldrop"
+validate_output "ServiceMonitor relabelings" "${TESTS_DIR}/test-values.yaml" "targetLabel: cluster"
 validate_not_present "No ServiceMonitor by default" "" "kind: ServiceMonitor"
+validate_not_present "No metricRelabelings when unset" "" "metricRelabelings" "--set serviceMonitor.enabled=true"
 
 # Existing secret validation (should NOT create new secrets)
 validate_not_present "No Kafka secret when using existing" "${TESTS_DIR}/test-values-existing-secret.yaml" "name: test-release-klag-kafka"

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -68,7 +68,7 @@ For SASL/SSL, common settings include `KAFKA_SECURITY_PROTOCOL`,
 | `METRICS_GROUP_FILTER` | `*` | Comma-separated glob include patterns. |
 | `METRICS_GROUP_EXCLUDE` | _(empty)_ | Comma-separated glob exclude patterns. |
 | `METRICS_JVM_ENABLED` | `false` | Export JVM metrics. |
-| `CONSUMER_MEMBER_LABELS_ENABLED` | `true` | Tag consumer-owned per-partition lag metrics with `member_host` / `consumer_id` / `client_id` (kafka-lag-exporter parity). Set `false` to drop them and reduce cardinality. |
+| `CONSUMER_MEMBER_LABELS_ENABLED` | `true` | Tag consumer-owned per-partition lag metrics with `member_host` / `consumer_id` / `client_id` (kafka-lag-exporter parity). Set `false` to drop them and reduce cardinality. Cheaper than Prometheus `labeldrop` of the same names, which still scrapes the series first. |
 | `LAG_TREND_DEADBAND_MSG_PER_SEC` | `1.0` | STABLE band for the MCP lag-trend classifier. |
 | `COMMIT_FRESHNESS_ENABLED` | `true` | Track inferred time since a lagging group/topic's committed-offset sum last changed. |
 | `ISR_ENABLED` | `true` | Detect and report under-replicated partitions. |

--- a/website/src/content/docs/deployment/kubernetes.md
+++ b/website/src/content/docs/deployment/kubernetes.md
@@ -73,7 +73,10 @@ The chart rejects a ServiceMonitor with a non-Prometheus reporter because `/metr
 would return `404`. Add labels under `serviceMonitor.labels` when your Prometheus
 Operator uses a label selector. Use `serviceMonitor.metricRelabelings` (post-scrape)
 and `serviceMonitor.relabelings` (pre-scrape) to drop high-cardinality labels or mint
-extra labels without a second ServiceMonitor. See
+extra labels without a second ServiceMonitor. Dropping `member_host`, `consumer_id`,
+and `client_id` with `labeldrop` overlaps
+`CONSUMER_MEMBER_LABELS_ENABLED=false`, which is cheaper — Klag never builds those
+series. See
 [Troubleshooting](/guides/troubleshooting/#prometheus-does-not-discover-the-servicemonitor)
 for namespace and selector checks.
 

--- a/website/src/content/docs/deployment/kubernetes.md
+++ b/website/src/content/docs/deployment/kubernetes.md
@@ -71,7 +71,9 @@ helm upgrade --install klag klag/klag \
 
 The chart rejects a ServiceMonitor with a non-Prometheus reporter because `/metrics`
 would return `404`. Add labels under `serviceMonitor.labels` when your Prometheus
-Operator uses a label selector. See
+Operator uses a label selector. Use `serviceMonitor.metricRelabelings` (post-scrape)
+and `serviceMonitor.relabelings` (pre-scrape) to drop high-cardinality labels or mint
+extra labels without a second ServiceMonitor. See
 [Troubleshooting](/guides/troubleshooting/#prometheus-does-not-discover-the-servicemonitor)
 for namespace and selector checks.
 

--- a/website/src/content/docs/metrics/overview.md
+++ b/website/src/content/docs/metrics/overview.md
@@ -47,7 +47,8 @@ series visible for one or two collection intervals.
 `klag.consumer.committed_offset` also carry `member_host`, `consumer_id`, and `client_id` tags
 identifying the consumer **instance** that owns each partition — handy for pinning lag to a
 specific pod. Unowned partitions (Empty/Dead groups) get empty-string values. Disable with
-`CONSUMER_MEMBER_LABELS_ENABLED=false` to cut cardinality. Topic-level `lag.ms` aggregates and
+`CONSUMER_MEMBER_LABELS_ENABLED=false` to cut cardinality (cheaper than Prometheus
+`labeldrop` of the same names, which still scrapes the series first). Topic-level `lag.ms` aggregates and
 partition-level `klag.partition.log_*_offset` metrics stay member-agnostic.
 
 ## Hot partitions


### PR DESCRIPTION
Let Prometheus Operator rewrite scrape labels from chart values so operators do not need a second ServiceMonitor or a chart fork.

## Summary by Sourcery

Allow operators to customize Prometheus scrape and metric labels through Helm values without maintaining an additional ServiceMonitor or chart fork.

New Features:
- Expose optional Prometheus Operator metric and target relabeling configuration through the Helm chart’s ServiceMonitor values.

Enhancements:
- Document relabeling use cases and clarify that disabling member labels in Klag avoids the scrape-time cost of dropping them in Prometheus.

Documentation:
- Update Helm and Kubernetes documentation with ServiceMonitor relabeling configuration and cardinality guidance.

Tests:
- Add Helm chart coverage for rendering configured relabelings and omitting them when unset.

Chores:
- Bump the Helm chart version to 0.3.10 and record the new ServiceMonitor options in chart metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Prometheus ServiceMonitor metric and target relabeling settings.
  - Supports dropping high-cardinality labels and adding labels such as `cluster` without another ServiceMonitor.
  - New settings are disabled by default.

- **Documentation**
  - Added Helm and Kubernetes configuration examples and parameter details.
  - Clarified the benefits of disabling consumer member labels.

- **Tests**
  - Added validation for relabeling behavior and default handling.

- **Chores**
  - Bumped the Helm chart version to 0.3.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->