### PR TITLE
fix: validate numeric configuration bounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,9 @@ Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAM
 
 **Kafka:** `KAFKA_BOOTSTRAP_SERVERS` (localhost:9092), `KAFKA_REQUEST_TIMEOUT_MS` (30000), `KAFKA_CHUNK_COUNT` (1 — chunking is *off*; only values >1 enable it), `KAFKA_CHUNK_DELAY_MS` (0), `KAFKA_MAX_CONCURRENT_GROUPS` (50 — caps how many consumer-group offset requests are in flight at once; a concurrency bound, not a throttle, so it applies regardless of chunking). Any other `KAFKA_X_Y_Z` env var maps to `kafka.x.y.z` and is forwarded to the AdminClient. Config precedence: classpath `application.properties` < external file at `KLAG_CONFIG_FILE` < `KAFKA_*` env vars.
 
+`KAFKA_CHUNK_COUNT` must be at least 1 and `KAFKA_CHUNK_DELAY_MS` must be non-negative.
+Invalid values loaded through `Env` log a warning and fall back to the defaults above.
+
 **Metrics:** `METRICS_REPORTER` (none/prometheus/datadog/otlp), `METRICS_INTERVAL_MS` (60000), `METRICS_GROUP_FILTER` (comma-separated glob patterns, default `*`), `METRICS_GROUP_EXCLUDE` (comma-separated glob patterns, default empty), `METRICS_JVM_ENABLED` (false), `CONSUMER_MEMBER_LABELS_ENABLED` (true — tag per-partition `klag.consumer.lag`, `klag.consumer.lag.ms`, and `klag.consumer.committed_offset` with `member_host`/`consumer_id`/`client_id` for the owning consumer instance; kafka-lag-exporter parity. Empty-string values for unowned partitions; set `false` to drop the labels and cut cardinality), `LAG_TREND_DEADBAND_MSG_PER_SEC` (1.0 — STABLE band for the MCP basic lag-trend classifier; |velocity| within the band is STABLE). Every setting in this list is `Env`-backed and accepts both exact-name and dotted JVM properties, including `-DMETRICS_REPORTER=prometheus` and `-Dmetrics.reporter=prometheus`. A group is monitored iff it matches any include segment AND no exclude segment.
 
 **Hot Partition Detection:**
@@ -149,11 +152,19 @@ Any `Env`-backed variable resolves in order (first non-blank wins): env var `NAM
 - `HOT_PARTITION_MIN_SAMPLES` (3) - Minimum samples for throughput calculation
 - `HOT_PARTITION_BUFFER_SIZE` (20) - Samples to retain per partition
 
+The sigma multiplier must be finite and positive, minimum partitions and samples must be at
+least 2, and the buffer size must be at least the minimum sample count. Invalid or incompatible
+values log a warning and fall back to the documented defaults.
+
 **Time-Based Lag Estimation:**
 - `TIME_LAG_ENABLED` (true) - Enable/disable time-based lag estimation
 - `TIME_LAG_MIN_MESSAGES` (100) - Minimum lag messages required for time-to-close estimates
 - `TIME_LAG_INTERPOLATION_BUFFER_SIZE` (60) - Number of offset/timestamp points per partition for interpolation
 - `TIME_LAG_STALE_PRODUCER_THRESHOLD_MS` (180000) - Time in ms before a producer with no offset progress is considered stale
+
+Minimum lag messages must be non-negative, the interpolation buffer must contain at least 2
+points, and the stale-producer threshold must be positive. Invalid values log a warning and
+fall back to the documented defaults.
 
 **Commit Freshness:**
 - `COMMIT_FRESHNESS_ENABLED` (true) - Track time since each group+topic last advanced its committed offset. Kafka exposes no commit timestamp, so freshness is *inferred*: klag timestamps when the observed committed offset changes. The clock starts at klag startup and resets on restart (it measures time since klag last *observed* a commit, not the absolute commit time). Staleness is only reported while lag > 0. The MCP `diagnose` stuck-consumer flag fires at 300s (constant; alert on the raw gauge at any threshold).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,9 @@ Invalid values loaded through `Env` log a warning and fall back to the defaults 
 - `HOT_PARTITION_BUFFER_SIZE` (20) - Samples to retain per partition
 
 The sigma multiplier must be finite and positive, minimum partitions and samples must be at
-least 2, and the buffer size must be at least the minimum sample count. Invalid or incompatible
-values log a warning and fall back to the documented defaults.
+least 2, and the buffer size must be at least the minimum sample count. Invalid values log a
+warning and fall back to the documented defaults. If the buffer size is smaller than a valid
+minimum sample count, it is raised to the minimum sample count.
 
 **Time-Based Lag Estimation:**
 - `TIME_LAG_ENABLED` (true) - Enable/disable time-based lag estimation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.themoah"
-version = "0.2.15"
+version = "0.2.16"
 
 repositories {
   mavenCentral()

--- a/charts/klag/Chart.yaml
+++ b/charts/klag/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: klag
 description: A Helm chart for Klag - A simple, lightweight Kafka Lag Exporter with pluggable metrics sinks.
 type: application
-version: 0.3.12
-appVersion: "0.2.15"
+version: 0.3.13
+appVersion: "0.2.16"
 home: https://github.com/themoah/klag
 icon: https://avatars.githubusercontent.com/themoah
 sources:
@@ -34,6 +34,8 @@ annotations:
     - name: themoah
       email: aviv@dozorets.com
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Preserve HOT_PARTITION_MIN_SAMPLES when HOT_PARTITION_BUFFER_SIZE is too small by raising the buffer size to the configured minimum
     - kind: added
       description: Opt-in topic data-skew metric (klag.topic.size_skew = max/mean retained size × 100); enable with DATA_SKEW_ENABLED=true
     - kind: added

--- a/src/main/java/io/github/themoah/klag/kafka/ChunkConfig.java
+++ b/src/main/java/io/github/themoah/klag/kafka/ChunkConfig.java
@@ -44,6 +44,10 @@ public record ChunkConfig(
       log.warn("KAFKA_CHUNK_COUNT must be >= 1, using default: {}", DEFAULT_CHUNK_COUNT);
       chunkCount = DEFAULT_CHUNK_COUNT;
     }
+    if (chunkDelayMs < 0) {
+      log.warn("KAFKA_CHUNK_DELAY_MS must be >= 0, using default: {}", DEFAULT_CHUNK_DELAY_MS);
+      chunkDelayMs = DEFAULT_CHUNK_DELAY_MS;
+    }
 
     ChunkConfig config = new ChunkConfig(chunkCount, chunkDelayMs);
     log.info("Chunk config: chunkCount={}, chunkDelayMs={}, enabled={}",

--- a/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfig.java
+++ b/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfig.java
@@ -48,6 +48,27 @@ public record HotPartitionConfig(
     int minSamples = Env.getInt("HOT_PARTITION_MIN_SAMPLES", DEFAULT_MIN_SAMPLES);
     int bufferSize = Env.getInt("HOT_PARTITION_BUFFER_SIZE", DEFAULT_BUFFER_SIZE);
 
+    if (!Double.isFinite(sigma) || sigma <= 0) {
+      log.warn("HOT_PARTITION_SIGMA_MULTIPLIER must be finite and > 0, using default: {}",
+        DEFAULT_SIGMA_MULTIPLIER);
+      sigma = DEFAULT_SIGMA_MULTIPLIER;
+    }
+    if (minPartitions < 2) {
+      log.warn("HOT_PARTITION_MIN_PARTITIONS must be >= 2, using default: {}", DEFAULT_MIN_PARTITIONS);
+      minPartitions = DEFAULT_MIN_PARTITIONS;
+    }
+    if (minSamples < 2) {
+      log.warn("HOT_PARTITION_MIN_SAMPLES must be >= 2, using default: {}", DEFAULT_MIN_SAMPLES);
+      minSamples = DEFAULT_MIN_SAMPLES;
+    }
+    if (bufferSize < minSamples) {
+      log.warn("HOT_PARTITION_BUFFER_SIZE must be >= HOT_PARTITION_MIN_SAMPLES ({}), "
+          + "using defaults: HOT_PARTITION_MIN_SAMPLES={}, HOT_PARTITION_BUFFER_SIZE={}",
+        minSamples, DEFAULT_MIN_SAMPLES, DEFAULT_BUFFER_SIZE);
+      minSamples = DEFAULT_MIN_SAMPLES;
+      bufferSize = DEFAULT_BUFFER_SIZE;
+    }
+
     HotPartitionConfig config = new HotPartitionConfig(enabled, sigma, minPartitions, minSamples, bufferSize);
     log.info("Hot partition config: enabled={}, sigma={}, minPartitions={}, minSamples={}, bufferSize={}",
       enabled, sigma, minPartitions, minSamples, bufferSize);

--- a/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfig.java
+++ b/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfig.java
@@ -61,6 +61,10 @@ public record HotPartitionConfig(
       log.warn("HOT_PARTITION_MIN_SAMPLES must be >= 2, using default: {}", DEFAULT_MIN_SAMPLES);
       minSamples = DEFAULT_MIN_SAMPLES;
     }
+    if (bufferSize < 2) {
+      log.warn("HOT_PARTITION_BUFFER_SIZE must be >= 2, using default: {}", DEFAULT_BUFFER_SIZE);
+      bufferSize = DEFAULT_BUFFER_SIZE;
+    }
     if (bufferSize < minSamples) {
       log.warn("HOT_PARTITION_BUFFER_SIZE must be >= HOT_PARTITION_MIN_SAMPLES ({}), "
           + "using HOT_PARTITION_MIN_SAMPLES as buffer size: {}",

--- a/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfig.java
+++ b/src/main/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfig.java
@@ -63,10 +63,9 @@ public record HotPartitionConfig(
     }
     if (bufferSize < minSamples) {
       log.warn("HOT_PARTITION_BUFFER_SIZE must be >= HOT_PARTITION_MIN_SAMPLES ({}), "
-          + "using defaults: HOT_PARTITION_MIN_SAMPLES={}, HOT_PARTITION_BUFFER_SIZE={}",
-        minSamples, DEFAULT_MIN_SAMPLES, DEFAULT_BUFFER_SIZE);
-      minSamples = DEFAULT_MIN_SAMPLES;
-      bufferSize = DEFAULT_BUFFER_SIZE;
+          + "using HOT_PARTITION_MIN_SAMPLES as buffer size: {}",
+        minSamples, minSamples);
+      bufferSize = minSamples;
     }
 
     HotPartitionConfig config = new HotPartitionConfig(enabled, sigma, minPartitions, minSamples, bufferSize);

--- a/src/main/java/io/github/themoah/klag/metrics/timelag/TimeLagConfig.java
+++ b/src/main/java/io/github/themoah/klag/metrics/timelag/TimeLagConfig.java
@@ -43,6 +43,21 @@ public record TimeLagConfig(
     int interpolationBufferSize = Env.getInt("TIME_LAG_INTERPOLATION_BUFFER_SIZE", DEFAULT_INTERPOLATION_BUFFER_SIZE);
     long staleProducerThresholdMs = Env.getLong("TIME_LAG_STALE_PRODUCER_THRESHOLD_MS", DEFAULT_STALE_PRODUCER_THRESHOLD_MS);
 
+    if (minLagMessages < 0) {
+      log.warn("TIME_LAG_MIN_MESSAGES must be >= 0, using default: {}", DEFAULT_MIN_LAG_MESSAGES);
+      minLagMessages = DEFAULT_MIN_LAG_MESSAGES;
+    }
+    if (interpolationBufferSize < 2) {
+      log.warn("TIME_LAG_INTERPOLATION_BUFFER_SIZE must be >= 2, using default: {}",
+        DEFAULT_INTERPOLATION_BUFFER_SIZE);
+      interpolationBufferSize = DEFAULT_INTERPOLATION_BUFFER_SIZE;
+    }
+    if (staleProducerThresholdMs <= 0) {
+      log.warn("TIME_LAG_STALE_PRODUCER_THRESHOLD_MS must be > 0, using default: {}",
+        DEFAULT_STALE_PRODUCER_THRESHOLD_MS);
+      staleProducerThresholdMs = DEFAULT_STALE_PRODUCER_THRESHOLD_MS;
+    }
+
     TimeLagConfig config = new TimeLagConfig(enabled, minLagMessages, interpolationBufferSize, staleProducerThresholdMs);
     log.info("Time lag config: enabled={}, minLagMessages={}, interpolationBufferSize={}, staleProducerThresholdMs={}",
       enabled, minLagMessages, interpolationBufferSize, staleProducerThresholdMs);

--- a/src/test/java/io/github/themoah/klag/kafka/ChunkConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/kafka/ChunkConfigTest.java
@@ -1,0 +1,105 @@
+package io.github.themoah.klag.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+
+class ChunkConfigTest {
+
+  private static final String COUNT = "KAFKA_CHUNK_COUNT";
+  private static final String DELAY = "KAFKA_CHUNK_DELAY_MS";
+
+  @AfterEach
+  void clearProperties() {
+    System.clearProperty(COUNT);
+    System.clearProperty(DELAY);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "-1"})
+  void invalidChunkCountFallsBackToDefault(String value) {
+    System.setProperty(COUNT, value);
+
+    ChunkConfig config = ChunkConfig.fromEnvironment();
+
+    assertEquals(1, config.chunkCount());
+    assertFalse(config.isChunkingEnabled());
+  }
+
+  @Test
+  void negativeChunkDelayFallsBackToDefault() {
+    System.setProperty(DELAY, "-1");
+
+    ChunkConfig config = ChunkConfig.fromEnvironment();
+
+    assertEquals(0, config.chunkDelayMs());
+  }
+
+  @Test
+  void boundaryValuesArePreserved() {
+    System.setProperty(COUNT, "1");
+    System.setProperty(DELAY, "0");
+
+    ChunkConfig config = ChunkConfig.fromEnvironment();
+
+    assertEquals(1, config.chunkCount());
+    assertEquals(0, config.chunkDelayMs());
+    assertFalse(config.isChunkingEnabled());
+  }
+
+  @Test
+  void validCustomValuesArePreserved() {
+    System.setProperty(COUNT, "5");
+    System.setProperty(DELAY, "100");
+
+    ChunkConfig config = ChunkConfig.fromEnvironment();
+
+    assertEquals(5, config.chunkCount());
+    assertEquals(100, config.chunkDelayMs());
+    assertTrue(config.isChunkingEnabled());
+  }
+
+  @Test
+  void invalidValuesLogSettingsAndFallbacks() {
+    Logger logger = (Logger) LoggerFactory.getLogger(ChunkConfig.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      System.setProperty(COUNT, "0");
+      System.setProperty(DELAY, "-1");
+
+      ChunkConfig.fromEnvironment();
+
+      List<String> warnings = appender.list.stream()
+        .filter(event -> event.getLevel() == Level.WARN)
+        .map(ILoggingEvent::getFormattedMessage)
+        .toList();
+      assertEquals(List.of(
+        "KAFKA_CHUNK_COUNT must be >= 1, using default: 1",
+        "KAFKA_CHUNK_DELAY_MS must be >= 0, using default: 0"), warnings);
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void directConstructionRemainsUnvalidated() {
+    ChunkConfig config = new ChunkConfig(0, -1);
+
+    assertEquals(0, config.chunkCount());
+    assertEquals(-1, config.chunkDelayMs());
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfigTest.java
@@ -70,14 +70,14 @@ class HotPartitionConfigTest {
   }
 
   @Test
-  void bufferSmallerThanMinSamplesFallsBackToCompatibleDefaults() {
+  void bufferSmallerThanMinSamplesIsRaisedToMinSamples() {
     System.setProperty(MIN_SAMPLES, "30");
     System.setProperty(BUFFER_SIZE, "20");
 
     HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
 
-    assertEquals(3, config.minSamples());
-    assertEquals(20, config.bufferSize());
+    assertEquals(30, config.minSamples());
+    assertEquals(30, config.bufferSize());
   }
 
   @Test

--- a/src/test/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/hotpartition/HotPartitionConfigTest.java
@@ -1,0 +1,145 @@
+package io.github.themoah.klag.metrics.hotpartition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+
+class HotPartitionConfigTest {
+
+  private static final String SIGMA = "HOT_PARTITION_SIGMA_MULTIPLIER";
+  private static final String MIN_PARTITIONS = "HOT_PARTITION_MIN_PARTITIONS";
+  private static final String MIN_SAMPLES = "HOT_PARTITION_MIN_SAMPLES";
+  private static final String BUFFER_SIZE = "HOT_PARTITION_BUFFER_SIZE";
+
+  @AfterEach
+  void clearProperties() {
+    System.clearProperty(SIGMA);
+    System.clearProperty(MIN_PARTITIONS);
+    System.clearProperty(MIN_SAMPLES);
+    System.clearProperty(BUFFER_SIZE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "-1", "NaN", "Infinity", "-Infinity"})
+  void invalidSigmaFallsBackToDefault(String value) {
+    System.setProperty(SIGMA, value);
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(2.0, config.sigmaMultiplier());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "1", "-1"})
+  void invalidMinPartitionsFallsBackToDefault(String value) {
+    System.setProperty(MIN_PARTITIONS, value);
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(3, config.minPartitions());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "1", "-1"})
+  void invalidMinSamplesFallsBackToDefault(String value) {
+    System.setProperty(MIN_SAMPLES, value);
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(3, config.minSamples());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "1", "-1"})
+  void invalidBufferSizeFallsBackToCompatibleDefaults(String value) {
+    System.setProperty(BUFFER_SIZE, value);
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(3, config.minSamples());
+    assertEquals(20, config.bufferSize());
+  }
+
+  @Test
+  void bufferSmallerThanMinSamplesFallsBackToCompatibleDefaults() {
+    System.setProperty(MIN_SAMPLES, "30");
+    System.setProperty(BUFFER_SIZE, "20");
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(3, config.minSamples());
+    assertEquals(20, config.bufferSize());
+  }
+
+  @Test
+  void boundaryValuesArePreserved() {
+    System.setProperty(SIGMA, Double.toString(Double.MIN_VALUE));
+    System.setProperty(MIN_PARTITIONS, "2");
+    System.setProperty(MIN_SAMPLES, "2");
+    System.setProperty(BUFFER_SIZE, "2");
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(Double.MIN_VALUE, config.sigmaMultiplier());
+    assertEquals(2, config.minPartitions());
+    assertEquals(2, config.minSamples());
+    assertEquals(2, config.bufferSize());
+  }
+
+  @Test
+  void validCustomValuesArePreserved() {
+    System.setProperty(SIGMA, "3.5");
+    System.setProperty(MIN_PARTITIONS, "10");
+    System.setProperty(MIN_SAMPLES, "12");
+    System.setProperty(BUFFER_SIZE, "50");
+
+    HotPartitionConfig config = HotPartitionConfig.fromEnvironment();
+
+    assertEquals(3.5, config.sigmaMultiplier());
+    assertEquals(10, config.minPartitions());
+    assertEquals(12, config.minSamples());
+    assertEquals(50, config.bufferSize());
+  }
+
+  @Test
+  void invalidValueLogsSettingAndFallback() {
+    Logger logger = (Logger) LoggerFactory.getLogger(HotPartitionConfig.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      System.setProperty(SIGMA, "NaN");
+
+      HotPartitionConfig.fromEnvironment();
+
+      List<String> warnings = appender.list.stream()
+        .filter(event -> event.getLevel() == Level.WARN)
+        .map(ILoggingEvent::getFormattedMessage)
+        .toList();
+      assertEquals(List.of(
+        "HOT_PARTITION_SIGMA_MULTIPLIER must be finite and > 0, using default: 2.0"), warnings);
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void directConstructionRemainsUnvalidated() {
+    HotPartitionConfig config = new HotPartitionConfig(true, -1, 1, 10, 5);
+
+    assertEquals(-1, config.sigmaMultiplier());
+    assertEquals(1, config.minPartitions());
+    assertEquals(10, config.minSamples());
+    assertEquals(5, config.bufferSize());
+  }
+}

--- a/src/test/java/io/github/themoah/klag/metrics/timelag/TimeLagConfigTest.java
+++ b/src/test/java/io/github/themoah/klag/metrics/timelag/TimeLagConfigTest.java
@@ -1,0 +1,110 @@
+package io.github.themoah.klag.metrics.timelag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class TimeLagConfigTest {
+
+  private static final String MIN_MESSAGES = "TIME_LAG_MIN_MESSAGES";
+  private static final String BUFFER_SIZE = "TIME_LAG_INTERPOLATION_BUFFER_SIZE";
+  private static final String STALE_THRESHOLD = "TIME_LAG_STALE_PRODUCER_THRESHOLD_MS";
+
+  @AfterEach
+  void clearProperties() {
+    System.clearProperty(MIN_MESSAGES);
+    System.clearProperty(BUFFER_SIZE);
+    System.clearProperty(STALE_THRESHOLD);
+  }
+
+  @Test
+  void invalidValuesFallBackToDefaults() {
+    System.setProperty(MIN_MESSAGES, "-1");
+    System.setProperty(BUFFER_SIZE, "1");
+    System.setProperty(STALE_THRESHOLD, "0");
+
+    TimeLagConfig config = TimeLagConfig.fromEnvironment();
+
+    assertEquals(100, config.minLagMessages());
+    assertEquals(60, config.interpolationBufferSize());
+    assertEquals(180000, config.staleProducerThresholdMs());
+  }
+
+  @Test
+  void negativeStaleThresholdFallsBackToDefault() {
+    System.setProperty(STALE_THRESHOLD, "-1");
+
+    TimeLagConfig config = TimeLagConfig.fromEnvironment();
+
+    assertEquals(180000, config.staleProducerThresholdMs());
+  }
+
+  @Test
+  void boundaryValuesArePreserved() {
+    System.setProperty(MIN_MESSAGES, "0");
+    System.setProperty(BUFFER_SIZE, "2");
+    System.setProperty(STALE_THRESHOLD, "1");
+
+    TimeLagConfig config = TimeLagConfig.fromEnvironment();
+
+    assertEquals(0, config.minLagMessages());
+    assertEquals(2, config.interpolationBufferSize());
+    assertEquals(1, config.staleProducerThresholdMs());
+  }
+
+  @Test
+  void validCustomValuesArePreserved() {
+    System.setProperty(MIN_MESSAGES, "500");
+    System.setProperty(BUFFER_SIZE, "120");
+    System.setProperty(STALE_THRESHOLD, "300000");
+
+    TimeLagConfig config = TimeLagConfig.fromEnvironment();
+
+    assertEquals(500, config.minLagMessages());
+    assertEquals(120, config.interpolationBufferSize());
+    assertEquals(300000, config.staleProducerThresholdMs());
+  }
+
+  @Test
+  void invalidValuesLogSettingsAndFallbacks() {
+    Logger logger = (Logger) LoggerFactory.getLogger(TimeLagConfig.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    try {
+      System.setProperty(MIN_MESSAGES, "-1");
+      System.setProperty(BUFFER_SIZE, "1");
+      System.setProperty(STALE_THRESHOLD, "0");
+
+      TimeLagConfig.fromEnvironment();
+
+      List<String> warnings = appender.list.stream()
+        .filter(event -> event.getLevel() == Level.WARN)
+        .map(ILoggingEvent::getFormattedMessage)
+        .toList();
+      assertEquals(List.of(
+        "TIME_LAG_MIN_MESSAGES must be >= 0, using default: 100",
+        "TIME_LAG_INTERPOLATION_BUFFER_SIZE must be >= 2, using default: 60",
+        "TIME_LAG_STALE_PRODUCER_THRESHOLD_MS must be > 0, using default: 180000"), warnings);
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void directConstructionRemainsUnvalidated() {
+    TimeLagConfig config = new TimeLagConfig(true, -1, 1, 0);
+
+    assertEquals(-1, config.minLagMessages());
+    assertEquals(1, config.interpolationBufferSize());
+    assertEquals(0, config.staleProducerThresholdMs());
+  }
+}

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -105,7 +105,8 @@ See [Metrics Overview](/metrics/overview/) for commit-staleness semantics,
 | `HOT_PARTITION_BUFFER_SIZE` | `20` | Samples retained per partition. Must be at least `HOT_PARTITION_MIN_SAMPLES`. |
 
 Invalid hot-partition values log a warning and fall back to the documented defaults. If the
-minimum sample count exceeds the buffer size, both settings fall back to their defaults.
+minimum sample count exceeds the buffer size, the buffer size is raised to the minimum sample
+count.
 
 ## Time-based lag estimation
 

--- a/website/src/content/docs/configuration/reference.md
+++ b/website/src/content/docs/configuration/reference.md
@@ -48,8 +48,8 @@ resolve exact-name JVM properties such as
 |---|---|---|
 | `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Broker addresses. |
 | `KAFKA_REQUEST_TIMEOUT_MS` | `30000` | Request timeout. |
-| `KAFKA_CHUNK_COUNT` | `1` | Split offset requests into N batches. |
-| `KAFKA_CHUNK_DELAY_MS` | `0` | Delay (ms) between batches. |
+| `KAFKA_CHUNK_COUNT` | `1` | Split offset requests into N batches. Must be at least `1`; invalid values fall back to the default. |
+| `KAFKA_CHUNK_DELAY_MS` | `0` | Delay (ms) between batches. Must be non-negative; invalid values fall back to the default. |
 
 Any `KAFKA_X_Y_Z` environment variable is mapped to `kafka.x.y.z` and forwarded to the
 Kafka AdminClient. For example, `KAFKA_SECURITY_PROTOCOL` becomes
@@ -99,19 +99,24 @@ See [Metrics Overview](/metrics/overview/) for commit-staleness semantics,
 | Variable | Default | Description |
 |---|---|---|
 | `HOT_PARTITION_ENABLED` | `true` | Enable hot-partition detection. |
-| `HOT_PARTITION_SIGMA_MULTIPLIER` | `2.0` | Std-devs for the outlier threshold. |
-| `HOT_PARTITION_MIN_PARTITIONS` | `3` | Min partitions per topic for detection. |
-| `HOT_PARTITION_MIN_SAMPLES` | `3` | Min samples for throughput calc. |
-| `HOT_PARTITION_BUFFER_SIZE` | `20` | Samples retained per partition. |
+| `HOT_PARTITION_SIGMA_MULTIPLIER` | `2.0` | Std-devs for the outlier threshold. Must be finite and positive. |
+| `HOT_PARTITION_MIN_PARTITIONS` | `3` | Min partitions per topic for detection. Must be at least `2`. |
+| `HOT_PARTITION_MIN_SAMPLES` | `3` | Min samples for throughput calc. Must be at least `2`. |
+| `HOT_PARTITION_BUFFER_SIZE` | `20` | Samples retained per partition. Must be at least `HOT_PARTITION_MIN_SAMPLES`. |
+
+Invalid hot-partition values log a warning and fall back to the documented defaults. If the
+minimum sample count exceeds the buffer size, both settings fall back to their defaults.
 
 ## Time-based lag estimation
 
 | Variable | Default | Description |
 |---|---|---|
 | `TIME_LAG_ENABLED` | `true` | Enable time-based lag estimation. |
-| `TIME_LAG_MIN_MESSAGES` | `100` | Min lag messages for time-to-close estimates. |
-| `TIME_LAG_INTERPOLATION_BUFFER_SIZE` | `60` | Offset/timestamp points per partition. |
-| `TIME_LAG_STALE_PRODUCER_THRESHOLD_MS` | `180000` | Time before a producer is considered stale. |
+| `TIME_LAG_MIN_MESSAGES` | `100` | Min lag messages for time-to-close estimates. Must be non-negative. |
+| `TIME_LAG_INTERPOLATION_BUFFER_SIZE` | `60` | Offset/timestamp points per partition. Must be at least `2`. |
+| `TIME_LAG_STALE_PRODUCER_THRESHOLD_MS` | `180000` | Time before a producer is considered stale. Must be positive. |
+
+Invalid time-lag values log a warning and fall back to the documented defaults.
 
 ## MCP (AI agent access)
 


### PR DESCRIPTION
## Summary

- Validate numeric hot-partition, time-lag, and Kafka chunk settings loaded from the environment
- Fall back to documented defaults with clear warnings for invalid values
- Enforce the `bufferSize >= minSamples` cross-field invariant
- Preserve direct record construction for focused unit tests
- Document the supported bounds and fallback behavior

## Testing

- Added focused tests for invalid, boundary, and valid custom values
- Added assertions for warning messages and fallback values
- Full test suite passing: 393 tests

Closes #83

## Summary by Sourcery

Validate environment-sourced numeric configuration and enforce compatible bounds while preserving documented defaults and direct configuration construction.

Bug Fixes:
- Validate numeric Kafka chunk, hot-partition, and time-lag settings loaded from the environment, warning and falling back to safe defaults when values are invalid.
- Ensure hot-partition buffer capacity is never below the configured minimum sample count.

Enhancements:
- Document supported configuration bounds, fallback behavior, and the hot-partition cross-field constraint.

Build:
- Bump the application version to 0.2.16 and Helm chart version to 0.3.13.

Documentation:
- Update configuration reference documentation with numeric bounds and invalid-value handling.

Tests:
- Add focused coverage for invalid, boundary, custom, warning, fallback, and direct-construction behavior across the affected configuration types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for Kafka chunking, hot-partition detection, and time-based lag settings.
  * Invalid configuration values now generate warnings and fall back to documented defaults.
  * Hot-partition buffer sizing now preserves the configured minimum sample requirement.

* **Documentation**
  * Updated configuration reference with accepted value ranges and fallback behavior.

* **Tests**
  * Added coverage for invalid, boundary, and valid values, including warning logs.

* **Release**
  * Updated the application and Helm chart versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->